### PR TITLE
fix(macos): hardening scripts fixes (per-user settings, audit accuracy, rollback, firewall, checks-only)

### DIFF
--- a/macos/checks/cis_checks.sh
+++ b/macos/checks/cis_checks.sh
@@ -12,7 +12,9 @@ cis_check_filevault() {
         success "✓ CIS 2.6.1 - FileVault is enabled"
         return 0
     else
-        warn "✗ CIS 2.6.1 - FileVault is not enabled"
+        # Critical control: emit as a failure (not a warning) so disk
+        # encryption being off is reflected in the score, not half-credited.
+        error "✗ CIS 2.6.1 - FileVault is not enabled"
         return 1
     fi
 }
@@ -20,28 +22,170 @@ cis_check_filevault() {
 # CIS compliance check for Firewall
 cis_check_firewall() {
     info "Checking Firewall compliance"
-    local firewall_state=""
 
-    firewall_state="$(defaults read /Library/Preferences/com.apple.alf globalstate 2>/dev/null || true)"
-
-    if [[ ! "$firewall_state" =~ ^[0-9]+$ ]] && [[ -x /usr/libexec/ApplicationFirewall/socketfilterfw ]]; then
-        firewall_state="$(
-            /usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate 2>/dev/null \
-                | sed -nE 's/.*State = ([0-9]+).*/\1/p'
-        )"
-    fi
-
-    # ↓ Ajout ici, après les deux tentatives de lecture
-    if [[ -z "$firewall_state" ]]; then
-        warn "✗ CIS 2.7.1 - Impossible de lire l'état du pare-feu"
-        return 1
-    fi
-
-    if [[ "$firewall_state" == "1" || "$firewall_state" == "2" ]]; then
+    # macOS 15+ prints "blocking all non-essential" in block-all mode, not
+    # "Firewall is enabled". Match every on variant; only "disabled" fails.
+    if /usr/libexec/ApplicationFirewall/socketfilterfw --getglobalstate 2>/dev/null \
+        | grep -Eqi "firewall is enabled|blocking all non-essential|set to block all"; then
         success "✓ CIS 2.7.1 - Firewall is enabled"
         return 0
     else
-        warn "✗ CIS 2.7.1 - Firewall is not enabled"
+        error "✗ CIS 2.7.1 - Firewall is not enabled"
+        return 1
+    fi
+}
+
+# CIS compliance check for Firewall hardening (stealth mode + block all incoming)
+# The plain firewall check above only confirms it is ON. The feedback showed a
+# firewall that was on but with stealth mode and "block all incoming" not set,
+# which the audit did not flag. This catches that.
+cis_check_firewall_hardening() {
+    info "Checking Firewall stealth mode and block-all-incoming"
+
+    local fw="/usr/libexec/ApplicationFirewall/socketfilterfw"
+    local issues=0
+
+    if [[ ! -x "$fw" ]]; then
+        info "→ CIS 2.7 - socketfilterfw not present on this build, skipping stealth/block-all check"
+        return 0
+    fi
+
+    # Stealth mode only matters while the firewall is on: macOS keeps the stealth
+    # preference set even after the firewall is turned off, which made this report
+    # a false pass. Gate it on the firewall actually being enabled.
+    local fw_on=false
+    if "$fw" --getglobalstate 2>/dev/null | grep -Eqi "firewall is enabled|blocking all non-essential|set to block all"; then
+        fw_on=true
+    fi
+
+    # Modern: "stealth mode is on"; legacy: "Stealth mode enabled".
+    if [[ "$fw_on" == true ]] && "$fw" --getstealthmode 2>/dev/null | grep -Eqi "stealth mode is on|stealth mode enabled"; then
+        success "✓ CIS 2.7.2 - Firewall stealth mode is enabled"
+    elif [[ "$fw_on" != true ]]; then
+        warn "✗ CIS 2.7.2 - Firewall stealth mode is off (the firewall itself is disabled)"
+        issues=$((issues+1))
+    else
+        warn "✗ CIS 2.7.2 - Firewall stealth mode is not enabled"
+        issues=$((issues+1))
+    fi
+
+    # Block-all is an optional, Paranoid-only control because it breaks AirDrop,
+    # printer and file sharing. Off is the intended state for the Recommended
+    # profile, so report it as info (neutral), never a failure.
+    if "$fw" --getblockall 2>/dev/null | grep -Eqi "blocking all non-essential|set to block all"; then
+        success "✓ CIS 2.7.3 - Firewall blocks all incoming connections"
+    else
+        info "→ CIS 2.7.3 - Block all incoming is off (intended for Recommended; the Paranoid profile turns it on)"
+    fi
+
+    return $issues
+}
+
+# CIS compliance check for pending software updates.
+# Uses the cached LastUpdatesAvailable count so the check stays instant and
+# offline. The feedback flagged that an outdated macOS/Safari was not surfaced.
+cis_check_software_updates() {
+    info "Checking for pending software updates"
+
+    local pending
+    pending="$(defaults read /Library/Preferences/com.apple.SoftwareUpdate LastUpdatesAvailable 2>/dev/null)"
+
+    if [[ -z "$pending" ]]; then
+        info "→ CIS 1.1 - Update status unknown (no cached update count). Open Software Update to refresh."
+        return 0
+    fi
+
+    if [[ "$pending" -eq 0 ]] 2>/dev/null; then
+        success "✓ CIS 1.1 - No pending software updates"
+        return 0
+    else
+        # Informational, not scored: a detected pending update is real system
+        # state that a snapshot restore cannot undo (you cannot un-detect an
+        # available update), so counting it against the score would make the
+        # score fail to return to baseline after a restore. The user still sees
+        # it and can install from System Settings.
+        info "→ CIS 1.1 - $pending pending software update(s) available; install from System Settings (not counted in the score)"
+        return 0
+    fi
+}
+
+# CIS compliance check for screen-lock password settings (per user).
+# Reads the real state via `sysadminctl -screenLock status`; the old
+# com.apple.screensaver askForPassword keys are inert on macOS 13+.
+cis_check_lockscreen() {
+    info "Checking lock screen password settings"
+
+    local issues=0
+    local status
+    status="$(user_screenlock_status 2>/dev/null)"
+
+    if [[ -n "$status" ]]; then
+        if echo "$status" | grep -qi "screenLock is off"; then
+            warn "✗ CIS 5.9 - Screen lock is off: a password is not required after the screen saver or display turns off"
+            issues=$((issues+1))
+        elif echo "$status" | grep -qi "screenLock delay is immediate"; then
+            success "✓ CIS 5.9 - Screen lock requires a password immediately"
+        elif echo "$status" | grep -Eqi "screenLock delay is [0-9]+ seconds"; then
+            local secs
+            secs="$(echo "$status" | grep -Eo "[0-9]+ seconds" | grep -Eo "[0-9]+")"
+            if [[ -n "$secs" && "$secs" -le 5 ]] 2>/dev/null; then
+                success "✓ CIS 5.9 - Screen lock password delay is short ($secs seconds)"
+            else
+                warn "✗ CIS 5.9 - Screen lock password delay is too long (${secs:-unknown} seconds); set it to Immediately"
+                issues=$((issues+1))
+            fi
+        else
+            warn "✗ CIS 5.9 - Screen lock state could not be read; verify manually in System Settings > Lock Screen"
+            issues=$((issues+1))
+        fi
+        return $issues
+    fi
+
+    # Fallback when no console user resolved (e.g. an SSH-only audit).
+    local ask delay
+    ask="$(user_defaults_read com.apple.screensaver askForPassword 2>/dev/null)"
+    delay="$(user_defaults_read com.apple.screensaver askForPasswordDelay 2>/dev/null)"
+
+    # Keep delay numeric: it comes from the user's defaults domain, and a
+    # non-numeric value in the -le arithmetic context would be evaluated.
+    if [[ "$ask" == "1" && "$delay" =~ ^[0-9]+$ ]] && (( delay <= 5 )); then
+        success "✓ CIS 5.9 - Screen lock password appears required (legacy read, confirm in System Settings > Lock Screen)"
+    else
+        warn "✗ CIS 5.9 - Screen lock could not be confirmed; set Require password to Immediately in System Settings > Lock Screen"
+        issues=$((issues+1))
+    fi
+
+    return $issues
+}
+
+# CIS compliance check: require an administrator password for system-wide settings.
+cis_check_admin_required() {
+    info "Checking admin password requirement for system settings"
+
+    local shared
+    shared="$(security authorizationdb read system.preferences 2>/dev/null | plutil -extract shared raw - 2>/dev/null)"
+
+    if [[ "$shared" == "false" ]]; then
+        success "✓ CIS 5.11 - Administrator password required for system-wide settings"
+        return 0
+    else
+        warn "✗ CIS 5.11 - Administrator password is not required for system-wide settings"
+        return 1
+    fi
+}
+
+# CIS compliance check: show all filename extensions (per user).
+cis_check_file_extensions() {
+    info "Checking filename extension visibility"
+
+    local show
+    show="$(user_defaults_read NSGlobalDomain AppleShowAllExtensions 2>/dev/null)"
+
+    if [[ "$show" == "1" ]]; then
+        success "✓ CIS 6.2 - All filename extensions are shown"
+        return 0
+    else
+        warn "✗ CIS 6.2 - All filename extensions are not shown"
         return 1
     fi
 }
@@ -54,7 +198,7 @@ cis_check_gatekeeper() {
         success "✓ CIS 2.8 - Gatekeeper is enabled"
         return 0
     else
-        warn "✗ CIS 2.8 - Gatekeeper is not enabled"
+        error "✗ CIS 2.8 - Gatekeeper is not enabled"
         return 1
     fi
 }
@@ -65,12 +209,15 @@ cis_check_remote_services() {
     
     local issues=0
     
-    # Check SSH
-    if systemsetup -getremotelogin | grep -q "Remote Login: Off"; then
-        success "✓ CIS 2.4.5 - SSH is disabled"
-    else
+    # Check SSH (remote login). systemsetup -getremotelogin needs Full Disk
+    # Access and fails under the GUI's root-without-FDA context, returning an
+    # admin error that is easily misread as "SSH enabled". The sshd launchd job
+    # state is readable without FDA and reflects the same on/off.
+    if launchctl print system/com.openssh.sshd >/dev/null 2>&1; then
         warn "✗ CIS 2.4.5 - SSH is enabled"
-        ((issues++))
+        issues=$((issues+1))
+    else
+        success "✓ CIS 2.4.5 - SSH is disabled"
     fi
     
     # Check Screen Sharing
@@ -78,15 +225,22 @@ cis_check_remote_services() {
         success "✓ CIS 2.4.3 - Screen Sharing is disabled"
     else
         warn "✗ CIS 2.4.3 - Screen Sharing is enabled"
-        ((issues++))
+        issues=$((issues+1))
     fi
     
-    # Check Remote Apple Events
-    if systemsetup -getremoteappleevents | grep -q "Remote Apple Events: Off"; then
+    # Check Remote Apple Events. Capture stderr too and branch explicitly: any
+    # output that is neither "On" nor "Off" (a systemsetup error, or the feature
+    # being absent on newer Mac models) is reported as not-applicable rather than
+    # a false "enabled".
+    local rae
+    rae="$(systemsetup -getremoteappleevents 2>&1)"
+    if echo "$rae" | grep -qi "remote apple events: on"; then
+        warn "✗ CIS 2.4.1 - Remote Apple Events enabled"
+        issues=$((issues+1))
+    elif echo "$rae" | grep -qi "remote apple events: off"; then
         success "✓ CIS 2.4.1 - Remote Apple Events disabled"
     else
-        warn "✗ CIS 2.4.1 - Remote Apple Events enabled"
-        ((issues++))
+        info "→ CIS 2.4.1 - Remote Apple Events state unavailable (often not present on newer Macs)"
     fi
     
     return $issues
@@ -103,7 +257,7 @@ cis_check_user_settings() {
         success "✓ CIS 5.8 - Automatic login is disabled"
     else
         warn "✗ CIS 5.8 - Automatic login is enabled"
-        ((issues++))
+        issues=$((issues+1))
     fi
     
     # Check guest account
@@ -111,16 +265,12 @@ cis_check_user_settings() {
         success "✓ CIS 6.1.3 - Guest account is disabled"
     else
         warn "✗ CIS 6.1.3 - Guest account is enabled"
-        ((issues++))
+        issues=$((issues+1))
     fi
     
-    # Check password screensaver
-    if defaults read com.apple.screensaver askForPassword 2>/dev/null | grep -q "1"; then
-        success "✓ CIS 5.9 - Password required for screensaver"
-    else
-        warn "✗ CIS 5.9 - Password not required for screensaver"
-        ((issues++))
-    fi
-    
+    # Password screensaver is covered in detail by cis_check_lockscreen (read
+    # from the login user's domain, not root). Not repeated here to avoid a
+    # duplicate, wrong-domain CIS 5.9 row.
+
     return $issues
 }

--- a/macos/checks/opsek_checks.sh
+++ b/macos/checks/opsek_checks.sh
@@ -7,8 +7,27 @@
 # OPSEK compliance check for Bluetooth
 opsek_check_bluetooth() {
     info "Checking OPSEK Bluetooth compliance"
-    
-    if defaults read /Library/Preferences/com.apple.Bluetooth ControllerPowerState 2>/dev/null | grep -q "0"; then
+
+    # Read the live controller state, which is what System Settings reflects. The
+    # old check read the stale system ControllerPowerState key with an unanchored
+    # grep "0", so it reported a false "disabled" while Bluetooth was actually on.
+    local state
+    state="$(system_profiler SPBluetoothDataType 2>/dev/null)"
+
+    if echo "$state" | grep -Eqi "State: On|Bluetooth Power: On"; then
+        warn "✗ OPSEK - Bluetooth is not disabled"
+        return 1
+    elif echo "$state" | grep -Eqi "State: Off|Bluetooth Power: Off"; then
+        success "✓ OPSEK - Bluetooth is disabled"
+        return 0
+    fi
+
+    # Fallback when system_profiler does not expose the state: require the system
+    # power key to be exactly 0 AND the user ByHost power to be off or absent.
+    local cps user_pe
+    cps="$(defaults read /Library/Preferences/com.apple.Bluetooth ControllerPowerState 2>/dev/null)"
+    user_pe="$(user_defaults_read_currenthost com.apple.Bluetooth PowerEnabled 2>/dev/null)"
+    if [[ "$cps" == "0" && ( -z "$user_pe" || "$user_pe" == "0" ) ]]; then
         success "✓ OPSEK - Bluetooth is disabled"
         return 0
     else
@@ -42,22 +61,84 @@ opsek_check_wifi() {
     fi
 }
 
-# OPSEK compliance check for Lockdown Mode
+# OPSEK compliance check for Lockdown Mode.
+# Always evaluated now (the feedback noted Lockdown Mode being off was never
+# flagged). Apple exposes no reliable read-only API for the real Lockdown Mode
+# state, so we use the per-user Safari proxy key the hardening sets. Read it
+# from the login user, not root.
 opsek_check_lockdown_mode() {
     info "Checking OPSEK Lockdown Mode compliance"
-    
-    if [[ "$ENABLE_LOCKDOWN" != true ]]; then
-        info "→ OPSEK - Lockdown Mode was not requested (use --lockdown)"
-        return 0
-    fi
-    
-    if defaults read com.apple.Safari LockdownModeEnabled 2>/dev/null | grep -q "1"; then
+
+    if user_defaults_read com.apple.Safari LockdownModeEnabled 2>/dev/null | grep -q "1"; then
         success "✓ OPSEK - Lockdown Mode settings are enabled"
         return 0
     else
-        warn "✗ OPSEK - Lockdown Mode settings are not enabled"
+        warn "✗ OPSEK - Lockdown Mode is not enabled (turn it on in System Settings > Privacy & Security, then restart)"
         return 1
     fi
+}
+
+# OPSEK compliance check for AirDrop, Handoff and the AirPlay receiver (per user).
+# Reads the live OS state (sharingd DiscoverableMode, useractivityd, controlcenter)
+# rather than OPSEK's own markers, so a change in System Settings shows on the scan.
+opsek_check_airdrop_handoff() {
+    info "Checking OPSEK AirDrop, Handoff and AirPlay compliance"
+
+    local issues=0
+
+    # AirDrop
+    local mode
+    mode="$(user_defaults_read com.apple.sharingd DiscoverableMode 2>/dev/null)"
+    if [[ -n "$mode" ]]; then
+        case "$mode" in
+            Off)
+                success "✓ OPSEK - AirDrop receiving is off"
+                ;;
+            "Contacts Only")
+                warn "✗ OPSEK - AirDrop is discoverable by Contacts Only; set it to No One when not in use"
+                issues=$((issues+1))
+                ;;
+            *)
+                # Strip control bytes: log_message uses echo -e and $mode is
+                # user-controlled.
+                local mode_safe
+                mode_safe="$(printf '%s' "$mode" | LC_ALL=C tr -d '[:cntrl:]')"
+                warn "✗ OPSEK - AirDrop is discoverable ($mode_safe); set it to No One"
+                issues=$((issues+1))
+                ;;
+        esac
+    elif user_defaults_read com.apple.NetworkBrowser DisableAirDrop 2>/dev/null | grep -q "^1$"; then
+        success "✓ OPSEK - AirDrop is disabled"
+    else
+        warn "✗ OPSEK - AirDrop is not disabled"
+        issues=$((issues+1))
+    fi
+
+    # Absent keys mean enabled; off only when every scope reads an explicit 0.
+    local handoff_off=true key val
+    for key in ActivityReceivingAllowed ActivityAdvertisingAllowed; do
+        val="$(user_defaults_read_currenthost com.apple.coreservices.useractivityd "$key" 2>/dev/null)"
+        [[ -z "$val" ]] && val="$(user_defaults_read com.apple.coreservices.useractivityd "$key" 2>/dev/null)"
+        [[ "$val" != "0" ]] && handoff_off=false
+    done
+    if [[ "$handoff_off" == true ]]; then
+        success "✓ OPSEK - Handoff is disabled"
+    else
+        warn "✗ OPSEK - Handoff is not disabled"
+        issues=$((issues+1))
+    fi
+
+    # AirPlay receiver
+    local airplay
+    airplay="$(user_defaults_read_currenthost com.apple.controlcenter AirplayRecieverEnabled 2>/dev/null)"
+    if [[ "$airplay" == "0" ]]; then
+        success "✓ OPSEK - AirPlay receiver is off"
+    else
+        warn "✗ OPSEK - AirPlay receiver is enabled"
+        issues=$((issues+1))
+    fi
+
+    return $issues
 }
 
 # OPSEK compliance check for keyboard security
@@ -66,20 +147,23 @@ opsek_check_keyboard_security() {
     
     local issues=0
     
-    # Check if automatic spelling correction is disabled
-    if defaults read NSGlobalDomain NSAutomaticSpellingCorrectionEnabled 2>/dev/null | grep -q "0"; then
+    # Check if automatic spelling correction is disabled. Read the LOGIN USER's
+    # domain (secure_keyboard_settings writes it via user_execute), not root's:
+    # under the GUI's elevated run a bare `defaults read` hits /var/root and the
+    # warning never cleared no matter how often Paranoid was applied.
+    if user_defaults_read NSGlobalDomain NSAutomaticSpellingCorrectionEnabled 2>/dev/null | grep -q "0"; then
         success "✓ OPSEK - Automatic spelling correction disabled"
     else
         warn "✗ OPSEK - Automatic spelling correction enabled"
-        ((issues++))
+        issues=$((issues+1))
     fi
-    
-    # Check if automatic capitalization is disabled
-    if defaults read NSGlobalDomain NSAutomaticCapitalizationEnabled 2>/dev/null | grep -q "0"; then
+
+    # Check if automatic capitalization is disabled (login user's domain, as above).
+    if user_defaults_read NSGlobalDomain NSAutomaticCapitalizationEnabled 2>/dev/null | grep -q "0"; then
         success "✓ OPSEK - Automatic capitalization disabled"
     else
         warn "✗ OPSEK - Automatic capitalization enabled"
-        ((issues++))
+        issues=$((issues+1))
     fi
     
     return $issues

--- a/macos/config/profiles.conf
+++ b/macos/config/profiles.conf
@@ -2,8 +2,15 @@
 # Format: PROFILE_NAME="function1 function2 function3"
 
 # Recommended profile - balanced security
+# Ordering note: remote-access and sharing services are disabled BEFORE the
+# firewall is enabled. Enabling the firewall while Remote Apple Events / Remote
+# Application Scripting is on triggers the macOS "Blocked by Firewall" conflict,
+# so those services must be turned off first.
 PROFILE_RECOMMENDED="
     update_system
+    disable_remote_apple_events
+    disable_internet_sharing
+    disable_printer_sharing
     enable_firewall
     enable_gatekeeper
     configure_screensaver
@@ -12,9 +19,6 @@ PROFILE_RECOMMENDED="
     disable_guest_account
     show_filename_extensions
     disable_safari_safe_files
-    disable_remote_apple_events
-    disable_internet_sharing
-    disable_printer_sharing
     enable_filevault
     enable_security_auditing
     configure_time_sync
@@ -34,9 +38,20 @@ PROFILE_RECOMMENDED="
 "
 
 # Paranoid profile - maximum restrictions
+# Ordering note: every remote-access and sharing service is disabled BEFORE the
+# firewall (and block-all) is enabled, so macOS never raises the "Blocked by
+# Firewall" conflict on Remote Apple Events / Remote Application Scripting.
 PROFILE_PARANOID="
     update_system
+    disable_remote_apple_events
+    disable_internet_sharing
+    disable_printer_sharing
+    disable_screen_sharing
+    disable_file_sharing
+    disable_remote_management
+    disable_remote_login
     enable_firewall
+    enable_firewall_block_all
     enable_gatekeeper
     configure_screensaver
     disable_automatic_login
@@ -44,9 +59,6 @@ PROFILE_PARANOID="
     disable_guest_account
     show_filename_extensions
     disable_safari_safe_files
-    disable_remote_apple_events
-    disable_internet_sharing
-    disable_printer_sharing
     enable_filevault
     enable_security_auditing
     configure_time_sync
@@ -63,9 +75,6 @@ PROFILE_PARANOID="
     disable_siri_dictation
     disable_diagnostics
     secure_safari
-    disable_screen_sharing
-    disable_file_sharing
-    disable_remote_management
     disable_wake_on_lan
     configure_audit_flags
     configure_audit_retention

--- a/macos/install.sh
+++ b/macos/install.sh
@@ -77,6 +77,11 @@ create_directories() {
             info "Directory already exists: $dir"
         fi
     done
+
+    # Let the non-root GUI list snapshots: /var/backups ships 700 root:wheel.
+    # 711 traverse-only on the parent, 755 on our root; backup_<ts> dirs stay 700.
+    sudo chmod 711 /var/backups
+    sudo chmod 755 /var/backups/macos_hardening
 }
 
 

--- a/macos/main.sh
+++ b/macos/main.sh
@@ -34,6 +34,8 @@ FORCE_YES=false
 VERBOSE=false
 ENABLE_LOCKDOWN=false
 ENABLE_CHECKS=false
+CHECKS_ONLY=false
+SNAPSHOT_ONLY=false
 GENERATE_MDM=false
 MDM_PROFILE="recommended"
 MDM_OUTPUT_DIR="$SCRIPT_DIR/mdm_profiles"
@@ -61,26 +63,40 @@ run_cis_checks() {
     local total_issues=0
     
     # CIS compliance checks
-    cis_check_filevault || ((total_issues++))
-    cis_check_firewall || ((total_issues++))
-    cis_check_gatekeeper || ((total_issues++))
-    
-    local remote_issues
-    cis_check_remote_services
-    remote_issues=$?
+    cis_check_filevault || total_issues=$((total_issues+1))
+    cis_check_firewall || total_issues=$((total_issues+1))
+    cis_check_gatekeeper || total_issues=$((total_issues+1))
+    cis_check_software_updates || total_issues=$((total_issues+1))
+    cis_check_admin_required || total_issues=$((total_issues+1))
+    cis_check_file_extensions || total_issues=$((total_issues+1))
+
+    # Capture multi-issue counts with `|| var=$?` so a non-zero return (issues
+    # found) does not trip `set -e` and abort the audit mid-run.
+    local fw_issues=0
+    cis_check_firewall_hardening || fw_issues=$?
+    total_issues=$((total_issues + fw_issues))
+
+    local lock_issues=0
+    cis_check_lockscreen || lock_issues=$?
+    total_issues=$((total_issues + lock_issues))
+
+    local remote_issues=0
+    cis_check_remote_services || remote_issues=$?
     total_issues=$((total_issues + remote_issues))
-    
-    local user_issues
-    cis_check_user_settings
-    user_issues=$?
+
+    local user_issues=0
+    cis_check_user_settings || user_issues=$?
     total_issues=$((total_issues + user_issues))
     
+    # Aggregate summary line. Emitted as info, not success/warn, so the GUI
+    # parser does not count it as an extra passed/failed check on top of the
+    # individual cis_check_* results above.
     if [[ $total_issues -eq 0 ]]; then
-        success "All CIS compliance checks passed"
+        info "All CIS compliance checks passed"
     else
-        warn "$total_issues CIS compliance issues found"
+        info "$total_issues CIS compliance issues found"
     fi
-    
+
     return $total_issues
 }
 
@@ -92,27 +108,35 @@ run_opsek_checks() {
     
     # OPSEK specific checks
     if function_exists "opsek_check_bluetooth"; then
-        opsek_check_bluetooth || ((total_issues++))
+        opsek_check_bluetooth || total_issues=$((total_issues+1))
     fi
     
     if function_exists "opsek_check_wifi"; then
-        opsek_check_wifi || ((total_issues++))
+        opsek_check_wifi || total_issues=$((total_issues+1))
     fi
     
     if function_exists "opsek_check_lockdown_mode"; then
-        opsek_check_lockdown_mode || ((total_issues++))
+        opsek_check_lockdown_mode || total_issues=$((total_issues+1))
     fi
     
     if function_exists "opsek_check_keyboard_security"; then
-        opsek_check_keyboard_security || ((total_issues++))
+        opsek_check_keyboard_security || total_issues=$((total_issues+1))
     fi
-    
+
+    if function_exists "opsek_check_airdrop_handoff"; then
+        local airdrop_issues=0
+        opsek_check_airdrop_handoff || airdrop_issues=$?
+        total_issues=$((total_issues + airdrop_issues))
+    fi
+
+    # Aggregate summary line, emitted as info for the same reason as the CIS
+    # summary above (avoid double-counting in the GUI score).
     if [[ $total_issues -eq 0 ]]; then
-        success "All OPSEK compliance checks passed"
+        info "All OPSEK compliance checks passed"
     else
-        warn "$total_issues OPSEK compliance issues found"
+        info "$total_issues OPSEK compliance issues found"
     fi
-    
+
     return $total_issues
 }
 
@@ -125,6 +149,8 @@ while [[ ${#} -gt 0 ]]; do
         --paranoid) PROFILE="paranoid"; shift ;;
         --lockdown) ENABLE_LOCKDOWN=true; shift ;;
         --checks) ENABLE_CHECKS=true; shift ;;
+        --checks-only) CHECKS_ONLY=true; ENABLE_CHECKS=true; shift ;;
+        --snapshot-only) SNAPSHOT_ONLY=true; FORCE_YES=true; shift ;;
         --dry-run) DRY_RUN=true; shift ;;
         --yes) FORCE_YES=true; shift ;;
         --verbose) VERBOSE=true; shift ;;
@@ -201,70 +227,91 @@ main() {
     else
         info "Backup directory: $CURRENT_BACKUP"
     fi
-    
-    # Display warning and get confirmation if interactive
-    if [[ "$FORCE_YES" != true ]] && [[ "$DRY_RUN" != true ]]; then
-        echo
-        warn "WARNING: This script will modify system security settings."
-        warn "Profile: $PROFILE"
-        if [[ "$ENABLE_LOCKDOWN" == true ]]; then
-            warn "Lockdown Mode: ENABLED (may impact web browsing)"
+
+    # Standalone restore point: capture the current system state (so it can be
+    # rolled back to) without applying any hardening, then exit. Used by the GUI
+    # "Create snapshot" button so users can save a checkpoint on demand.
+    if [[ "$SNAPSHOT_ONLY" == true ]]; then
+        if [[ "$DRY_RUN" == false ]]; then
+            snapshot_system_state paranoid
+            generate_rollback_script "$CURRENT_BACKUP" "$TIMESTAMP"
+            write_snapshot_metadata "$CURRENT_BACKUP" "$TIMESTAMP"
+            success "Restore point saved in: $CURRENT_BACKUP"
+        else
+            info "Dry-run: no restore point created."
         fi
-        warn "A backup will be created at: $CURRENT_BACKUP"
-        echo
-        read -p "Continue with hardening? (y/N): " -n 1 -r
-        echo
-        [[ ! $REPLY =~ ^[Yy]$ ]] && { info "Hardening cancelled by user"; exit 0; }
-    fi
-    
-    # Validate profile
-    if ! validate_profile "$PROFILE"; then
-        error "Profile validation failed"
-        exit 1
-    fi
-    
-    # Apply selected profile
-    echo
-    if ! apply_profile "$PROFILE"; then
-        error "Failed to apply profile: $PROFILE"
-        exit 1
+        exit 0
     fi
 
-    # Apply optional Lockdown-compatible restrictions when explicitly requested.
-    if [[ "$ENABLE_LOCKDOWN" == true ]]; then
-        echo
-        if function_exists "enable_lockdown_mode"; then
-            if ! enable_lockdown_mode; then
-                warn "Lockdown Mode compatible settings were not fully applied"
+    # Apply the hardening profile, unless we were asked to only run the
+    # read-only compliance checks. --checks-only is used by the GUI audit so
+    # the score reflects the real system state and is not mixed with a profile
+    # dry-run that would otherwise be applied here first.
+    if [[ "$CHECKS_ONLY" != true ]]; then
+        # Display warning and get confirmation if interactive
+        if [[ "$FORCE_YES" != true ]] && [[ "$DRY_RUN" != true ]]; then
+            echo
+            warn "WARNING: This script will modify system security settings."
+            warn "Profile: $PROFILE"
+            if [[ "$ENABLE_LOCKDOWN" == true ]]; then
+                warn "Lockdown Mode: ENABLED (may impact web browsing)"
             fi
-        else
-            error "Lockdown Mode module is not available"
+            warn "A backup will be created at: $CURRENT_BACKUP"
+            echo
+            read -p "Continue with hardening? (y/N): " -n 1 -r
+            echo
+            [[ ! $REPLY =~ ^[Yy]$ ]] && { info "Hardening cancelled by user"; exit 0; }
+        fi
+
+        # Validate profile
+        if ! validate_profile "$PROFILE"; then
+            error "Profile validation failed"
             exit 1
         fi
+
+        # Apply selected profile
+        echo
+        if ! apply_profile "$PROFILE"; then
+            error "Failed to apply profile: $PROFILE"
+            exit 1
+        fi
+
+        # Create rollback script if not dry-run
+        if [[ "$DRY_RUN" == false ]]; then
+            generate_rollback_script "$CURRENT_BACKUP" "$TIMESTAMP"
+            write_snapshot_metadata "$CURRENT_BACKUP" "$TIMESTAMP"
+            success "Hardening applied and backup stored in: $CURRENT_BACKUP"
+        else
+            info "Dry-run finished. No changes were applied."
+        fi
     fi
-    
-    # Create rollback script if not dry-run
-    if [[ "$DRY_RUN" == false ]]; then
-        generate_rollback_script "$CURRENT_BACKUP" "$TIMESTAMP"
-        success "Hardening applied and backup stored in: $CURRENT_BACKUP"
-    else
-        info "Dry-run finished. No changes were applied."
-    fi
-    
+
     # Run compliance checks if requested
     local compliance_issues=0
-    
+
     if [[ "$ENABLE_CHECKS" == true ]]; then
         echo
-        run_cis_checks
-        compliance_issues=$?
+        # Capture each with `|| var=$?`: the functions return the issue count,
+        # and a bare non-zero return would trip set -e and abort main() before
+        # run_opsek_checks ran.
+        # Markers so a combined apply+checks run (GUI Apply uses --checks) can
+        # isolate the check rows from the apply log noise when parsing the score.
+        echo "OPSEK_CHECKS_BEGIN"
+        local cis_issues=0
+        run_cis_checks || cis_issues=$?
 
         echo
-        local opsek_issues
-        run_opsek_checks
-        opsek_issues=$?
-        compliance_issues=$((compliance_issues + opsek_issues))
-        show_summary "$PROFILE" "$compliance_issues"
+        local opsek_issues=0
+        run_opsek_checks || opsek_issues=$?
+        echo "OPSEK_CHECKS_END"
+
+        compliance_issues=$((cis_issues + opsek_issues))
+
+        # The hardening summary banner only makes sense when a profile was
+        # actually applied. In checks-only mode the checks are the output.
+        if [[ "$CHECKS_ONLY" != true ]]; then
+            show_summary "$PROFILE" "$compliance_issues"
+        fi
     fi
 
 }

--- a/macos/modules/cis/network.sh
+++ b/macos/modules/cis/network.sh
@@ -18,10 +18,10 @@ disable_bluetooth_discoverable() {
 show_bluetooth_status() {
     info "CIS 2.1.3 - Showing Bluetooth status in menu bar"
     
-    backup_file "$HOME/Library/Preferences/com.apple.systemuiserver.plist"
-    
-    execute "defaults write ~/Library/Preferences/com.apple.systemuiserver 'NSStatusItem Visible com.apple.menu.bluetooth' -bool true"
-    execute "defaults write ~/Library/Preferences/com.apple.systemuiserver menuExtras -array-add '/System/Library/CoreServices/Menu Extras/Bluetooth.menu'"
+    user_backup_file "Library/Preferences/com.apple.systemuiserver.plist"
+
+    user_execute "defaults write com.apple.systemuiserver 'NSStatusItem Visible com.apple.menu.bluetooth' -bool true"
+    user_execute "defaults write com.apple.systemuiserver menuExtras -array-add '/System/Library/CoreServices/Menu Extras/Bluetooth.menu'"
     
 }
 

--- a/macos/modules/cis/permissions.sh
+++ b/macos/modules/cis/permissions.sh
@@ -53,13 +53,15 @@ fix_library_permissions() {
 # CIS 5.2 - Password Policy
 configure_password_policy() {
     info "CIS 5.2 - Configuring password policy"
-    
-    # Set minimum password length
+
+    # Content rules only, applied when a password is next changed. We do NOT set
+    # an expiration: maxMinutesUntilChangePassword locked users out whose current
+    # password was already older than the limit, and forced rotation is
+    # discouraged by NIST 800-63B. Content rules never reject the current password.
     execute "pwpolicy -n /Local/Default -setglobalpolicy 'minChars=14'"
     execute "pwpolicy -n /Local/Default -setglobalpolicy 'requiresAlpha=1'"
     execute "pwpolicy -n /Local/Default -setglobalpolicy 'requiresNumeric=1'"
-    execute "pwpolicy -n /Local/Default -setglobalpolicy 'maxMinutesUntilChangePassword=525600'"
-    
+
 }
 
 # CIS 5.3 - Reduce the sudo timeout period
@@ -89,27 +91,31 @@ configure_sudo_timeout() {
 # CIS 5.4 - Automatically lock the login keychain for inactivity
 configure_keychain_lock() {
     info "CIS 5.4 - Configuring keychain auto-lock"
-    
-    execute "security set-keychain-settings -t 21600 -l ~/Library/Keychains/login.keychain"
-    
+
+    # Run as the login user with no explicit path so `security` operates on
+    # that user's default (login) keychain. Run as root, `~` was /var/root and
+    # the bare `login.keychain` name was not in root's search list, so this
+    # always failed.
+    user_execute "security set-keychain-settings -t 21600 -l"
+
 }
 
 # CIS 5.5 - Ensure login keychain is locked when the computer sleeps
 configure_keychain_sleep_lock() {
     info "CIS 5.5 - Configuring keychain lock on sleep"
-    
-    execute "security set-keychain-settings -l ~/Library/Keychains/login.keychain"
-    
+
+    user_execute "security set-keychain-settings -l"
+
 }
 
 # CIS 5.6 - Enable OCSP and CRL certificate checking
 enable_certificate_checking() {
     info "CIS 5.6 - Enabling certificate revocation checking"
     
-    backup_file "$HOME/Library/Preferences/com.apple.security.revocation.plist"
-    
-    execute "defaults write com.apple.security.revocation CRLStyle -string RequireIfPresent"
-    execute "defaults write com.apple.security.revocation OCSPStyle -string RequireIfPresent"
+    user_backup_file "Library/Preferences/com.apple.security.revocation.plist"
+
+    user_execute "defaults write com.apple.security.revocation CRLStyle -string RequireIfPresent"
+    user_execute "defaults write com.apple.security.revocation OCSPStyle -string RequireIfPresent"
     
 }
 
@@ -134,12 +140,17 @@ disable_automatic_login() {
 # CIS 5.9 - Require a password to wake the computer from sleep or screen saver
 require_password_wake() {
     info "CIS 5.9 - Requiring password on wake"
-    
-    backup_file "$HOME/Library/Preferences/com.apple.screensaver.plist"
-    
-    execute "defaults write com.apple.screensaver askForPassword -int 1"
-    execute "defaults write com.apple.screensaver askForPasswordDelay -int 0"
-    
+
+    # Cannot be set from a script on macOS 13+ (sysadminctl needs the password,
+    # the defaults keys are inert), so detect the state and guide the user.
+    local status
+    status="$(user_screenlock_status 2>/dev/null)"
+
+    if echo "$status" | grep -qi "screenLock delay is immediate"; then
+        success "CIS 5.9 - A password is already required immediately after the screen saver"
+    else
+        warn "CIS 5.9 - Set Require password to Immediately in System Settings > Lock Screen. This cannot be set from a script on this macOS; the MDM profile can enforce it."
+    fi
 }
 
 # CIS 5.11 - Require an administrator password to access system-wide preferences
@@ -175,7 +186,7 @@ disable_fast_user_switching() {
 # CIS 5.16 - Secure individual keychains and items
 secure_keychains() {
     info "CIS 5.16 - Securing keychains"
-    
-    execute "security set-keychain-settings -t 21600 -l login.keychain"
-    
+
+    user_execute "security set-keychain-settings -t 21600 -l"
+
 }

--- a/macos/modules/cis/services.sh
+++ b/macos/modules/cis/services.sh
@@ -40,6 +40,23 @@ disable_printer_sharing() {
 }
 
 
+# CIS 2.4.5 - Disable Remote Login (SSH)
+disable_remote_login() {
+    info "CIS 2.4.5 - Disabling Remote Login (SSH)"
+
+    # The audit reads the sshd launchd job (launchctl print system/com.openssh.sshd),
+    # which is readable without Full Disk Access, so tearing that job down is what
+    # flips the check to disabled. bootout stops the running job now; disable keeps
+    # it from relaunching at boot. Both are root-capable and need no FDA.
+    execute "launchctl bootout system/com.openssh.sshd 2>/dev/null || true"
+    execute "launchctl disable system/com.openssh.sshd 2>/dev/null || true"
+
+    # The supported toggle as a complement. It needs the calling app to hold Full
+    # Disk Access (the onboarding now enforces it); -f skips the interactive
+    # confirmation, and the guard keeps a no-FDA run from failing the whole step.
+    execute "systemsetup -f -setremotelogin off 2>/dev/null || true"
+}
+
 # CIS 2.4.6 - Disable File Sharing
 disable_file_sharing() {
     info "CIS 2.4.6 - Disabling File Sharing"
@@ -68,11 +85,16 @@ disable_wake_on_lan() {
 # CIS 2.11 - Disabling AirDrop
 disable_airdrop() {
     info "CIS 2.11 - Disabling AirDrop"
-    
-    backup_file "$HOME/Library/Preferences/com.apple.NetworkBrowser.plist"
-    
-    execute "defaults write com.apple.NetworkBrowser DisableAirDrop -bool true"
 
+    # Live AirDrop posture on macOS 13+ is sharingd DiscoverableMode. Write it,
+    # then restart sharingd (it caches the mode and rewrites its plist on exit).
+    user_backup_file "Library/Preferences/com.apple.sharingd.plist"
+    user_execute "defaults write com.apple.sharingd DiscoverableMode -string Off"
+    user_execute "killall sharingd 2>/dev/null || true"
+
+    # Legacy marker for old systems and as an audit fallback.
+    user_backup_file "Library/Preferences/com.apple.NetworkBrowser.plist"
+    user_execute "defaults write com.apple.NetworkBrowser DisableAirDrop -bool true"
 }
 
 # CIS 4.1 - Disable Bonjour advertising service

--- a/macos/modules/cis/system.sh
+++ b/macos/modules/cis/system.sh
@@ -30,13 +30,14 @@ configure_time_sync() {
 # CIS 2.3.1 - Set an inactivity interval of 20 minutes or less for the screen saver
 configure_screensaver() {
     info "CIS 2.3.1 - Configuring screen saver timeout"
-    
-    backup_file ~/Library/Preferences/com.apple.screensaver.plist
-    
-    execute "defaults write com.apple.screensaver askForPassword -int 1"
-    execute "defaults write com.apple.screensaver askForPasswordDelay -int 0"
-    execute "defaults write com.apple.screensaver idleTime -int 1200"
-    
+
+    user_backup_file "Library/Preferences/com.apple.screensaver.plist"
+
+    # Idle timeout lives in the ByHost domain (-currentHost); 1200s = 20 min.
+    user_execute "defaults -currentHost write com.apple.screensaver idleTime -int 1200"
+
+    # The password requirement (CIS 5.9) is not set here: the defaults keys are
+    # inert on macOS 13+. See require_password_wake.
 }
 
 
@@ -56,13 +57,53 @@ enable_filevault() {
 # CIS 2.7.1 - Turn on Firewall
 enable_firewall() {
     info "CIS 2.7.1 - Enabling Application Firewall"
-    info "You can skip this step if the system is already secured by default (socketfilterfw no longer exists on newer Mac models)."
 
-    execute "/usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate on"
-    execute "/usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode on"
-    execute "/usr/libexec/ApplicationFirewall/socketfilterfw --setallowsigned off"
-    execute "/usr/libexec/ApplicationFirewall/socketfilterfw --setallowsignedapp off"
-    execute "/usr/libexec/ApplicationFirewall/socketfilterfw --setloggingmode on"
+    local fw="/usr/libexec/ApplicationFirewall/socketfilterfw"
+    if [[ ! -x "$fw" ]]; then
+        warn "Application Firewall control (socketfilterfw) is not present on this macOS build; skipping."
+        return 0
+    fi
+
+    # Firewall state for Restore is captured by snapshot_system_state into a
+    # dedicated firewall_restore.sh (applied last in the rollback). We do NOT
+    # back up com.apple.alf.plist: it is daemon-owned, and restoring it by cp
+    # makes the firewall daemon re-sync and clobber the toggle.
+
+    # Firewall on + stealth. Block-all is paranoid-only (see
+    # enable_firewall_block_all): it breaks AirDrop and sharing.
+    execute "$fw --setglobalstate on"
+    execute "$fw --setstealthmode on"
+
+    # Best-effort controls. Several socketfilterfw subcommands were removed or
+    # renamed on newer macOS builds, so any one of them can fail. Treat these as
+    # optional so the firewall still ends up on and stealthed.
+    execute "$fw --setallowsigned off" || warn "socketfilterfw --setallowsigned not supported on this build (ignored)"
+    execute "$fw --setallowsignedapp off" || warn "socketfilterfw --setallowsignedapp not supported on this build (ignored)"
+    execute "$fw --setloggingmode on" || warn "socketfilterfw --setloggingmode not supported on this build (ignored)"
+
+    return 0
+}
+
+# CIS 2.7.3 - Block all incoming connections (paranoid profile only).
+# Aggressive: breaks AirDrop and sharing, so it is not in the recommended profile.
+enable_firewall_block_all() {
+    info "CIS 2.7.3 - Blocking all incoming connections (paranoid)"
+
+    local fw="/usr/libexec/ApplicationFirewall/socketfilterfw"
+    if [[ ! -x "$fw" ]]; then
+        warn "Application Firewall control (socketfilterfw) is not present on this macOS build; skipping block-all."
+        return 0
+    fi
+
+    # Firewall state (including block-all) is captured for Restore by
+    # snapshot_system_state into firewall_restore.sh; the daemon-owned
+    # com.apple.alf.plist is intentionally not backed up (see enable_firewall).
+
+    # Ensure the firewall is on first, then block all non-essential incoming.
+    execute "$fw --setglobalstate on"
+    execute "$fw --setblockall on"
+
+    return 0
 }
 
 # CIS 2.8 - Enable Gatekeeper

--- a/macos/modules/cis/users.sh
+++ b/macos/modules/cis/users.sh
@@ -17,12 +17,17 @@ disable_automatic_login() {
 # CIS 5.9 - Require a password to wake the computer from sleep or screen saver
 require_password_wake() {
     info "CIS 5.9 - Requiring password on wake"
-    
-    backup_file "$HOME/Library/Preferences/com.apple.screensaver.plist"
-    
-    execute "defaults write com.apple.screensaver askForPassword -int 1"
-    execute "defaults write com.apple.screensaver askForPasswordDelay -int 0"
-    
+
+    # Cannot be set from a script on macOS 13+ (sysadminctl needs the password,
+    # the defaults keys are inert), so detect the state and guide the user.
+    local status
+    status="$(user_screenlock_status 2>/dev/null)"
+
+    if echo "$status" | grep -qi "screenLock delay is immediate"; then
+        success "CIS 5.9 - A password is already required immediately after the screen saver"
+    else
+        warn "CIS 5.9 - Set Require password to Immediately in System Settings > Lock Screen. This cannot be set from a script on this macOS; the MDM profile can enforce it."
+    fi
 }
 
 # CIS 5.11 - Require an administrator password to access system-wide preferences
@@ -66,16 +71,6 @@ set_login_message() {
     
 }
 
-
-# CIS 5.15 - Do not enter a password-based screensaver mode
-disable_password_screensaver_mode() {
-    info "CIS 5.15 - Configuring screensaver password mode"
-    
-    backup_file "$HOME/Library/Preferences/com.apple.screensaver.plist"
-    
-    execute "defaults write com.apple.screensaver askForPassword -int 1"
-    
-}
 
 # CIS 6.1.1 - Display login window as name and password
 configure_login_window_style() {
@@ -132,18 +127,20 @@ remove_guest_home() {
 show_filename_extensions() {
     info "CIS 6.2 - Showing filename extensions"
     
-    backup_file "$HOME/Library/Preferences/.GlobalPreferences.plist"
-    
-    execute "defaults write NSGlobalDomain AppleShowAllExtensions -bool true"
-    
+    user_backup_file "Library/Preferences/.GlobalPreferences.plist"
+
+    user_execute "defaults write NSGlobalDomain AppleShowAllExtensions -bool true"
+    # Restart Finder so the change is visible immediately for the user.
+    user_execute "killall Finder 2>/dev/null || true"
+
 }
 
 # CIS 6.3 - Disable the automatic run of safe files in Safari
 disable_safari_safe_files() {
     info "CIS 6.3 - Disabling Safari automatic safe file opening"
     
-    backup_file "$HOME/Library/Preferences/com.apple.Safari.plist"
-    
-    execute "defaults write com.apple.Safari AutoOpenSafeDownloads -bool false"
-    
+    user_backup_file "Library/Preferences/com.apple.Safari.plist"
+
+    user_execute "defaults write com.apple.Safari AutoOpenSafeDownloads -bool false"
+
 }

--- a/macos/modules/internals/bluetooth.sh
+++ b/macos/modules/internals/bluetooth.sh
@@ -9,14 +9,13 @@ disable_bluetooth_completely() {
     info "OPSEK - Completely disabling Bluetooth"
     
     backup_file "/Library/Preferences/com.apple.Bluetooth.plist"
-    backup_file "$HOME/Library/Preferences/com.apple.Bluetooth.plist"
-    backup_file "$HOME/Library/Preferences/ByHost/com.apple.Bluetooth.plist"
-    
+    user_backup_file "Library/Preferences/ByHost/com.apple.Bluetooth.plist"
+
     execute "defaults write /Library/Preferences/com.apple.Bluetooth ControllerPowerState -int 0"
     execute "launchctl unload -w /System/Library/LaunchDaemons/com.apple.blued.plist 2>/dev/null || true"
     execute "nvram bluetoothHostControllerSwitchBehavior=never"
-    execute "defaults write com.apple.Bluetooth PrefKeyServicesEnabled -bool false"
-    execute "defaults write ~/Library/Preferences/ByHost/com.apple.Bluetooth PowerEnabled -bool false"
+    user_execute "defaults write com.apple.Bluetooth PrefKeyServicesEnabled -bool false"
+    user_execute "defaults -currentHost write com.apple.Bluetooth PowerEnabled -bool false"
     
 }
 

--- a/macos/modules/internals/kernel.sh
+++ b/macos/modules/internals/kernel.sh
@@ -8,34 +8,34 @@
 secure_keyboard_settings() {
     info "OPSEK - Configuring secure keyboard settings"
     
-    backup_file "$HOME/Library/Preferences/.GlobalPreferences.plist"
-    backup_file "$HOME/Library/Preferences/com.apple.universalaccess.plist"
-    
+    user_backup_file "Library/Preferences/.GlobalPreferences.plist"
+    user_backup_file "Library/Preferences/com.apple.universalaccess.plist"
+
     # Disable press and hold for accented characters
-    execute "defaults write NSGlobalDomain ApplePressAndHoldEnabled -bool false"
-    
+    user_execute "defaults write NSGlobalDomain ApplePressAndHoldEnabled -bool false"
+
     # Set fast key repeat rate
-    execute "defaults write NSGlobalDomain KeyRepeat -int 2"
-    execute "defaults write NSGlobalDomain InitialKeyRepeat -int 15"
-    
+    user_execute "defaults write NSGlobalDomain KeyRepeat -int 2"
+    user_execute "defaults write NSGlobalDomain InitialKeyRepeat -int 15"
+
     # Disable automatic spelling correction
-    execute "defaults write NSGlobalDomain NSAutomaticSpellingCorrectionEnabled -bool false"
-    
+    user_execute "defaults write NSGlobalDomain NSAutomaticSpellingCorrectionEnabled -bool false"
+
     # Disable automatic capitalization
-    execute "defaults write NSGlobalDomain NSAutomaticCapitalizationEnabled -bool false"
-    
+    user_execute "defaults write NSGlobalDomain NSAutomaticCapitalizationEnabled -bool false"
+
     # Disable automatic period substitution
-    execute "defaults write NSGlobalDomain NSAutomaticPeriodSubstitutionEnabled -bool false"
-    
+    user_execute "defaults write NSGlobalDomain NSAutomaticPeriodSubstitutionEnabled -bool false"
+
     # Disable smart quotes and dashes
-    execute "defaults write NSGlobalDomain NSAutomaticQuoteSubstitutionEnabled -bool false"
-    execute "defaults write NSGlobalDomain NSAutomaticDashSubstitutionEnabled -bool false"
-    
+    user_execute "defaults write NSGlobalDomain NSAutomaticQuoteSubstitutionEnabled -bool false"
+    user_execute "defaults write NSGlobalDomain NSAutomaticDashSubstitutionEnabled -bool false"
+
     # Disable keyboard navigation to move focus between controls
-    execute "defaults write NSGlobalDomain AppleKeyboardUIMode -int 3"
-    
+    user_execute "defaults write NSGlobalDomain AppleKeyboardUIMode -int 3"
+
     # Secure keyboard access for assistive devices
-    execute "defaults write com.apple.universalaccess keyboardNavigation -bool true"
+    user_execute "defaults write com.apple.universalaccess keyboardNavigation -bool true"
     
 }
 

--- a/macos/modules/internals/lockdown.sh
+++ b/macos/modules/internals/lockdown.sh
@@ -17,42 +17,46 @@ enable_lockdown_mode() {
         return 1
     fi
     
-    # Backup files before modification
-    backup_file "$HOME/Library/Preferences/com.apple.Safari.plist"
-    backup_file "$HOME/Library/Preferences/com.apple.WebKit.plist"
-    backup_file "$HOME/Library/Preferences/.GlobalPreferences.plist"
-    backup_file "$HOME/Library/Preferences/com.apple.Messages.plist"
-    backup_file "$HOME/Library/Preferences/com.apple.facetime.plist"
-    
+    # Backup files before modification (read from the real user's home)
+    user_backup_file "Library/Preferences/com.apple.Safari.plist"
+    user_backup_file "Library/Preferences/com.apple.WebKit.plist"
+    user_backup_file "Library/Preferences/.GlobalPreferences.plist"
+    user_backup_file "Library/Preferences/com.apple.Messages.plist"
+    user_backup_file "Library/Preferences/com.apple.facetime.plist"
+
     # Enable Lockdown Mode via defaults
-    execute "defaults write com.apple.Safari LockdownModeEnabled -bool true"
-    execute "defaults write com.apple.WebKit LockdownModeEnabled -bool true"
-    
+    user_execute "defaults write com.apple.Safari LockdownModeEnabled -bool true"
+    user_execute "defaults write com.apple.WebKit LockdownModeEnabled -bool true"
+
     # Additional Lockdown Mode configurations
-    execute "defaults write NSGlobalDomain LockdownModeEnabled -bool true"
-    
+    user_execute "defaults write NSGlobalDomain LockdownModeEnabled -bool true"
+
     # Disable JIT compilation in Safari
-    execute "defaults write com.apple.Safari JavaScriptEnabled -bool false"
-    execute "defaults write com.apple.Safari WebKitJavaEnabled -bool false"
-    execute "defaults write com.apple.Safari WebKitPluginsEnabled -bool false"
-    
+    user_execute "defaults write com.apple.Safari JavaScriptEnabled -bool false"
+    user_execute "defaults write com.apple.Safari WebKitJavaEnabled -bool false"
+    user_execute "defaults write com.apple.Safari WebKitPluginsEnabled -bool false"
+
     # Disable complex web technologies
-    execute "defaults write com.apple.Safari WebGL2Enabled -bool false"
-    execute "defaults write com.apple.Safari WebGLEnabled -bool false"
-    
+    user_execute "defaults write com.apple.Safari WebGL2Enabled -bool false"
+    user_execute "defaults write com.apple.Safari WebGLEnabled -bool false"
+
     # Restrict font loading
-    execute "defaults write com.apple.Safari WebKitSuppressesIncrementalRenderingDuringLoading -bool true"
-    
+    user_execute "defaults write com.apple.Safari WebKitSuppressesIncrementalRenderingDuringLoading -bool true"
+
     # Disable preview attachments in Messages
-    execute "defaults write com.apple.Messages EnablePersistentConversions -bool false"
-    execute "defaults write com.apple.Messages LoadRemoteContent -bool false"
-    
+    user_execute "defaults write com.apple.Messages EnablePersistentConversions -bool false"
+    user_execute "defaults write com.apple.Messages LoadRemoteContent -bool false"
+
     # Disable FaceTime calls from unknown numbers
-    execute "defaults write com.apple.facetime blockUnknownCallers -bool true"
-    
-    # Note: Full Lockdown Mode requires manual activation in System Settings
-    warn "Note: Complete Lockdown Mode must be manually activated in System Settings > Privacy & Security"
-    warn "This function enables related security settings compatible with Lockdown Mode"
+    user_execute "defaults write com.apple.facetime blockUnknownCallers -bool true"
+
+    # IMPORTANT: Apple's actual Lockdown Mode cannot be toggled from the command
+    # line or via defaults. The keys above only configure related, compatible
+    # hardening. The real toggle lives in System Settings and must be turned on
+    # by the user, after which a restart is required. The audit reflects this:
+    # it reports Lockdown Mode as off until it is enabled there.
+    warn "Apple Lockdown Mode itself must be turned on manually in System Settings > Privacy & Security, then restart."
+    warn "This step applied the related, compatible hardening only."
     
     success "Lockdown Mode compatible settings enabled"
 }

--- a/macos/modules/internals/privacy.sh
+++ b/macos/modules/internals/privacy.sh
@@ -8,14 +8,14 @@
 disable_siri_dictation() {
     info "OPSEK - Disabling Siri and dictation"
     
-    backup_file "$HOME/Library/Preferences/com.apple.assistant.support.plist"
-    backup_file "$HOME/Library/Preferences/com.apple.Siri.plist"
-    backup_file "$HOME/Library/Preferences/com.apple.speech.recognition.AppleSpeechRecognition.prefs.plist"
-    
-    execute "defaults write com.apple.assistant.support 'Assistant Enabled' -bool false"
-    execute "defaults write com.apple.Siri StatusMenuVisible -bool false"
-    execute "defaults write com.apple.Siri UserHasDeclinedEnable -bool true"
-    execute "defaults write com.apple.speech.recognition.AppleSpeechRecognition.prefs DictationIMMasterDictationEnabled -bool false"
+    user_backup_file "Library/Preferences/com.apple.assistant.support.plist"
+    user_backup_file "Library/Preferences/com.apple.Siri.plist"
+    user_backup_file "Library/Preferences/com.apple.speech.recognition.AppleSpeechRecognition.prefs.plist"
+
+    user_execute "defaults write com.apple.assistant.support 'Assistant Enabled' -bool false"
+    user_execute "defaults write com.apple.Siri StatusMenuVisible -bool false"
+    user_execute "defaults write com.apple.Siri UserHasDeclinedEnable -bool true"
+    user_execute "defaults write com.apple.speech.recognition.AppleSpeechRecognition.prefs DictationIMMasterDictationEnabled -bool false"
     
 }
 
@@ -44,9 +44,9 @@ disable_location_services() {
 disable_spotlight_suggestions() {
     info "OPSEK - Disabling Spotlight suggestions"
     
-    backup_file "$HOME/Library/Preferences/com.apple.spotlight.plist"
-    
-    execute "defaults write com.apple.spotlight orderedItems -array \
+    user_backup_file "Library/Preferences/com.apple.spotlight.plist"
+
+    user_execute "defaults write com.apple.spotlight orderedItems -array \
         '{ enabled = 1; name = APPLICATIONS; }' \
         '{ enabled = 1; name = SYSTEM_PREFS; }' \
         '{ enabled = 1; name = DIRECTORIES; }' \
@@ -89,15 +89,15 @@ disable_ipv6_on_interfaces() {
 secure_safari() {
     info "OPSEK - Securing Safari browser"
     
-    backup_file "$HOME/Library/Preferences/com.apple.Safari.plist"
-    
-    execute "defaults write com.apple.Safari WebKitJavaEnabled -bool false"
-    execute "defaults write com.apple.Safari WebKitJavaScriptCanOpenWindowsAutomatically -bool false"
-    execute "defaults write com.apple.Safari SafariGeolocationPermissionPolicy -int 0"
-    execute "defaults write com.apple.Safari BlockStoragePolicy -int 1"
-    execute "defaults write com.apple.Safari WebKitStorageBlockingPolicy -int 1"
-    execute "defaults write com.apple.Safari SendDoNotTrackHTTPHeader -bool true"
-    execute "defaults write com.apple.Safari WarnAboutFraudulentWebsites -bool true"
+    user_backup_file "Library/Preferences/com.apple.Safari.plist"
+
+    user_execute "defaults write com.apple.Safari WebKitJavaEnabled -bool false"
+    user_execute "defaults write com.apple.Safari WebKitJavaScriptCanOpenWindowsAutomatically -bool false"
+    user_execute "defaults write com.apple.Safari SafariGeolocationPermissionPolicy -int 0"
+    user_execute "defaults write com.apple.Safari BlockStoragePolicy -int 1"
+    user_execute "defaults write com.apple.Safari WebKitStorageBlockingPolicy -int 1"
+    user_execute "defaults write com.apple.Safari SendDoNotTrackHTTPHeader -bool true"
+    user_execute "defaults write com.apple.Safari WarnAboutFraudulentWebsites -bool true"
     
 }
 
@@ -127,13 +127,25 @@ configure_privacy_settings() {
     execute "defaults write /Library/Application\ Support/CrashReporter/DiagnosticMessagesHistory.plist ThirdPartyDataSubmit -bool false"
     
     # Disable personalized ads
-    backup_file "$HOME/Library/Preferences/com.apple.AdLib.plist"
-    execute "defaults write com.apple.AdLib allowApplePersonalizedAdvertising -bool false"
-    execute "defaults write com.apple.AdLib allowIdentifierForAdvertising -bool false"
-    
-    # Disable Handoff
-    backup_file "$HOME/Library/Preferences/ByHost/com.apple.coreservices.useractivityd.plist"
-    execute "defaults write ~/Library/Preferences/ByHost/com.apple.coreservices.useractivityd ActivityAdvertisingAllowed -bool no"
-    execute "defaults write ~/Library/Preferences/ByHost/com.apple.coreservices.useractivityd ActivityReceivingAllowed -bool no"
-    
+    user_backup_file "Library/Preferences/com.apple.AdLib.plist"
+    user_execute "defaults write com.apple.AdLib allowApplePersonalizedAdvertising -bool false"
+    user_execute "defaults write com.apple.AdLib allowIdentifierForAdvertising -bool false"
+
+    # Disable Handoff (ByHost). Restart useractivityd so it takes effect now.
+    user_backup_file "Library/Preferences/ByHost/com.apple.coreservices.useractivityd.plist"
+    user_execute "defaults -currentHost write com.apple.coreservices.useractivityd ActivityAdvertisingAllowed -bool no"
+    user_execute "defaults -currentHost write com.apple.coreservices.useractivityd ActivityReceivingAllowed -bool no"
+    user_execute "killall useractivityd 2>/dev/null || true"
+
+    # Disable the AirPlay receiver (ByHost). Restart Control Center to refresh.
+    # Back up the ByHost controlcenter plist first so Restore reverts AirPlay (the
+    # OPSEK audit reads this). The file carries a hardware-UUID suffix, so glob it.
+    if [[ -n "$TARGET_HOME" ]]; then
+        for _cc in "$TARGET_HOME"/Library/Preferences/ByHost/com.apple.controlcenter.*.plist; do
+            [[ -f "$_cc" ]] && backup_file "$_cc"
+        done
+    fi
+    user_execute "defaults -currentHost write com.apple.controlcenter AirplayRecieverEnabled -bool false"
+    user_execute "killall ControlCenter 2>/dev/null || true"
+
 }

--- a/macos/modules/internals/wifi.sh
+++ b/macos/modules/internals/wifi.sh
@@ -19,11 +19,11 @@ disable_wifi() {
     done
     
     # Backup files before modification
-    backup_file "$HOME/Library/Preferences/com.apple.systemuiserver.plist"
+    user_backup_file "Library/Preferences/com.apple.systemuiserver.plist"
     backup_file "/Library/Preferences/SystemConfiguration/com.apple.airport.preferences.plist"
-    
-    # Disable Wi-Fi menu bar icon
-    execute "defaults write com.apple.systemuiserver 'NSStatusItem Visible com.apple.menu.airport' -bool false"
+
+    # Disable Wi-Fi menu bar icon (per-user)
+    user_execute "defaults write com.apple.systemuiserver 'NSStatusItem Visible com.apple.menu.airport' -bool false"
     
     # Prevent automatic joining of Wi-Fi networks
     execute "defaults write /Library/Preferences/SystemConfiguration/com.apple.airport.preferences DisableAssociation -bool true"

--- a/macos/tests/REVERT_COVERAGE.md
+++ b/macos/tests/REVERT_COVERAGE.md
@@ -1,0 +1,93 @@
+# Restore coverage matrix
+
+Every hardening function in `config/profiles.conf` (recommended + paranoid),
+how it is reverted by a snapshot, and how that revert is proven.
+
+Two revert mechanisms exist:
+
+- **file** — `backup_file` / `user_backup_file` saves the pre-Apply file; the
+  generated rollback `cp`s it back (per-user files are `chown`ed to the owner).
+- **journal** — `snapshot_system_state` records the inverse command in
+  `revert_state.sh` before Apply; the rollback replays it. Used for live toggles
+  and for configd/daemon-owned plists a raw `cp` cannot restore.
+
+A third class is **irreversible by design**: undoing it would weaken the Mac or
+cannot be done safely. These are intentionally not reverted AND are not read by
+any scored audit check, so a post-restore re-check can still reach baseline.
+
+The round-trip harness (`tests/roundtrip_test.sh`) executes the REAL capture and
+the REAL rollback against stubbed system commands and asserts every toggle
+returns to its pre-Apply value. Update this table AND the harness when adding a
+control.
+
+## Recommended profile
+
+| Function | Mechanism | Notes |
+|---|---|---|
+| update_system | file | SoftwareUpdate.plist |
+| disable_remote_apple_events | journal | launchctl AEServer (FDA-independent); absent on most Macs |
+| disable_internet_sharing | journal | nat (SystemConfiguration) via defaults |
+| disable_printer_sharing | journal | cupsctl + cupsd reload |
+| enable_firewall | journal | socketfilterfw global/stealth (was the main stuck control) |
+| enable_gatekeeper | journal | spctl |
+| configure_screensaver | file | per-user screensaver/loginwindow |
+| disable_automatic_login | file | loginwindow autoLoginUser |
+| require_password_wake | n/a | detect-only on macOS 13+, changes nothing |
+| disable_guest_account | file (+ irreversible part) | GuestEnabled reverts via plist; `sysadminctl -guestAccount off` account-level not reverted, not scored |
+| show_filename_extensions | file | per-user .GlobalPreferences |
+| disable_safari_safe_files | file | per-user Safari.plist |
+| enable_filevault | n/a | requires user interaction; rarely activates from script |
+| enable_security_auditing | file | audit_control; rollback reloads auditd |
+| configure_time_sync | n/a | not journaled (not scored, systemsetup needs FDA) |
+| disable_bonjour | file | mDNSResponder.plist |
+| secure_home_folders | **irreversible** | chmod 700 homes; not scored |
+| configure_password_policy | journal-equivalent | rollback clears account policies |
+| configure_keychain_lock | soft | per-user keychain timeout; not scored, not reverted |
+| enable_certificate_checking | file | per-user revocation.plist |
+| disable_root_account | **irreversible** | root stays disabled; not scored |
+| configure_hibernate_mode | journal | pmset |
+| set_login_message | file | loginwindow LoginwindowText |
+| disable_password_hints | file | loginwindow RetriesUntilHint |
+| disable_guest_shared_folders | journal | AppleFileServer + smb.server guest via defaults |
+| disable_siri_dictation | file | per-user assistant/Siri/speech plists |
+| disable_diagnostics | file | CrashReporter DiagnosticMessagesHistory |
+| secure_safari | file | per-user Safari.plist |
+
+## Paranoid profile (additional)
+
+| Function | Mechanism | Notes |
+|---|---|---|
+| disable_screen_sharing | journal | launchd screensharing |
+| disable_file_sharing | journal | launchd AppleFileServer + smbd |
+| disable_remote_management | journal | ARDAgent kickstart -activate (if was running) |
+| enable_firewall_block_all | journal | socketfilterfw blockall |
+| disable_wake_on_lan | journal | pmset womp |
+| configure_audit_flags / retention | file | audit_control |
+| disable_airdrop | file | per-user sharingd / NetworkBrowser |
+| disable_http_server / disable_nfs_server | journal | launchd httpd / nfsd |
+| check_application_permissions | **irreversible** | chmod o-w /Applications; not scored |
+| fix_system_permissions / fix_library_permissions | **irreversible** | chmod o-w; not scored |
+| configure_sudo_timeout | file | sudoers + rollback removes sudoers.d/timeout |
+| configure_keychain_sleep_lock / secure_keychains | soft | per-user keychain; not scored |
+| require_admin_system_prefs | journal | authorizationdb system.preferences shared (best-effort) |
+| disable_fast_user_switching | journal | system .GlobalPreferences MultipleSessionEnabled |
+| configure_login_window_style | file | loginwindow SHOWFULLNAME |
+| remove_guest_home | **irreversible** | /Users/Guest not recreated; not scored |
+| disable_location_services | journal | locationd via defaults |
+| disable_spotlight_suggestions | file | per-user spotlight.plist |
+| disable_unnecessary_daemons | journal | netbiosd, dhcp6d, alf.useragent, AppleShareClientCore |
+| configure_privacy_settings | file + journal | diagnostics/AdLib/Handoff file; AirPlay controlcenter ByHost file (scored) |
+| enhance_logging | file | installer.plist + audit_control |
+| disable_ipv6_on_interfaces | journal | networksetup setv6automatic |
+| disable_bluetooth_completely | file + journal | Bluetooth plists (power) + blued reload + nvram |
+| disable_all_bluetooth_services | journal | reloads bluetooth helper daemons/agents (kext reload needs restart) |
+| secure_keyboard_settings | file | per-user .GlobalPreferences + universalaccess |
+| disable_wifi | file + journal | airport power (journal) + association flags (journal) + menu (file) |
+| harden_kernel | journal | nvram boot-args + pmset |
+
+## Known soft cases (effect may need a restart/relogin)
+
+Daemon-cached domains (sharingd, controlcenter, locationd, useractivityd) are
+restored to the pre-Apply value, but the running daemon may only pick up the
+change after its next launch or a restart. The stored value is correct; the
+live effect can lag. The rollback restarts cfprefsd/SystemUIServer/Finder.

--- a/macos/tests/roundtrip_test.sh
+++ b/macos/tests/roundtrip_test.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# OPSEK restore round-trip test
+#
+# Proves the restore promise without touching the real machine: it sources the
+# REAL snapshot_system_state and the REAL generated rollback from utils/backup.sh,
+# with every system command replaced by a shell-function stub backed by an
+# in-memory STATE array. The test asserts that capture -> harden -> rollback
+# returns every toggle to its exact pre-Apply value.
+#
+# This is the gate that stops restore fidelity from eroding silently: when you
+# add a toggle to snapshot_system_state, add it to the INIT/harden/assert lists
+# here so a missing revert fails the test instead of shipping.
+#
+# Run: bash macos/tests/roundtrip_test.sh   (or via macos/tests/run.sh)
+# ==============================================================================
+
+# Repo root derived from this file, never hardcoded.
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS=0; FAIL=0
+ok(){ echo "  PASS: $1"; PASS=$((PASS+1)); }
+no(){ echo "  FAIL: $1"; FAIL=$((FAIL+1)); }
+
+# ---- Simulated system state -------------------------------------------------
+declare -A STATE
+declare -A INIT
+
+# ---- Command stubs (getters read STATE, setters mutate STATE) ----------------
+spctl(){ case "$1" in
+  --status) [[ "${STATE[gatekeeper]}" == enabled ]] && echo "assessments enabled" || echo "assessments disabled";;
+  --master-enable) STATE[gatekeeper]=enabled;; --master-disable) STATE[gatekeeper]=disabled;; esac; return 0; }
+
+# Application firewall stub. globalstate is 0/1/2; stealth/blockall are
+# enabled/disabled, matching socketfilterfw's real output shapes.
+socketfilterfw(){ case "$1" in
+  --getglobalstate) echo "Firewall is set. (State = ${STATE[fw_global]})";;
+  --getstealthmode) echo "Stealth mode ${STATE[fw_stealth]}";;
+  --getblockall)    echo "Block all ${STATE[fw_block]}";;
+  --setglobalstate) case "$2" in on|On) STATE[fw_global]=1;; off|Off) STATE[fw_global]=0;; esac;;
+  --setstealthmode) case "$2" in on|On) STATE[fw_stealth]=enabled;; off|Off) STATE[fw_stealth]=disabled;; esac;;
+  --setblockall)    case "$2" in on|On) STATE[fw_block]=enabled;; off|Off) STATE[fw_block]=disabled;; esac;;
+  esac; return 0; }
+
+systemsetup(){ case "$1" in
+  -getremoteappleevents) echo "Remote Apple Events: ${STATE[rae]}";;
+  -setremoteappleevents) case "$2" in on|On) STATE[rae]=On;; off|Off) STATE[rae]=Off;; esac;;
+  -getusingnetworktime) echo "Network Time: ${STATE[nettime]}";;
+  -setusingnetworktime) case "$2" in on|On) STATE[nettime]=On;; off|Off) STATE[nettime]=Off;; esac;;
+  -getnetworktimeserver) echo "Network Time Server: ${STATE[nettimeserver]}";;
+  -setnetworktimeserver) STATE[nettimeserver]="$2";; esac; return 0; }
+
+# defaults stub for the configd-owned / SystemConfiguration plists the journal
+# owns (a raw cp cannot restore them). Keyed by domain+key so per-key reverts
+# (airport association flags, .GlobalPreferences) work. Value is the LAST arg.
+defaults(){ local op="$1" domain="$2" key="$3"; local last="${@: -1}" id=""
+  case "$domain" in
+    *AppleFileServer*) id=afp_guest;;
+    *smb.server*) id=smb_guest;;
+    *nat*) id=nat;;
+    *airport.preferences*) id="airport_$key";;
+    *.GlobalPreferences*) id="gp_$key";;
+    *) return 0;;
+  esac
+  case "$op" in
+    read)  if [[ -n "${STATE[$id]+x}" ]]; then
+             if [[ "$id" == nat ]]; then echo "{ NAT = { Enabled = ${STATE[$id]}; }; }"; else echo "${STATE[$id]}"; fi; return 0
+           else return 1; fi;;
+    write)
+      # Mirror real defaults: -bool only accepts true|false|yes|no. A bare 0/1
+      # after -bool is an error (this is exactly the bug the helper must avoid).
+      if [[ "$*" == *"-bool"* ]]; then
+        case "$last" in
+          true|false|yes|no|YES|NO) ;;
+          *) echo "defaults: -bool requires true|false" >&2; return 255;;
+        esac
+      fi
+      case "$last" in true|YES|yes) STATE[$id]=1;; false|NO|no) STATE[$id]=0;; *) STATE[$id]="$last";; esac; return 0;;
+    delete) unset "STATE[$id]"; return 0;;
+  esac; return 0; }
+
+# Not exercised in the round-trip (paranoid authorizationdb revert); stubbed so
+# snapshot_system_state's capture probe does not hit the real tools.
+security(){ return 1; }
+plutil(){ return 1; }
+
+pmset(){ if [[ "$1" == -g ]]; then
+    printf ' womp                 %s\n' "${STATE[womp]}"
+    printf ' hibernatemode        %s\n' "${STATE[hibernatemode]}"
+    printf ' standby              %s\n' "${STATE[standby]}"
+  elif [[ "$1" == -a ]]; then STATE[$2]="$3"; fi; return 0; }
+
+networksetup(){ case "$1" in
+  -listallhardwareports) printf 'Hardware Port: Wi-Fi\nDevice: en0\n';;
+  -getairportpower) echo "Wi-Fi Power ($2): ${STATE[wifi_$2]}";;
+  -setairportpower) case "$3" in on|On) STATE[wifi_$2]=On;; off|Off) STATE[wifi_$2]=Off;; esac;;
+  -listallnetworkservices) printf 'An asterisk denotes...\nWi-Fi\n';;
+  -getinfo) echo "IPv6: ${STATE[ipv6_$2]}";;
+  -setv6automatic) STATE[ipv6_$2]=Automatic;; -setv6off) STATE[ipv6_$2]=Off;; esac; return 0; }
+
+nvram(){ if [[ "$1" == -d ]]; then unset "STATE[nvram_$2]"; return 0; fi
+  local a="$1"; if [[ "$a" == *=* ]]; then STATE[nvram_${a%%=*}]="${a#*=}"; return 0; fi
+  if [[ -n "${STATE[nvram_$a]+x}" ]]; then printf '%s\t%s\n' "$a" "${STATE[nvram_$a]}"; return 0; fi; return 1; }
+
+cupsctl(){ case "$1" in
+  --share-printers) STATE[cups_share]=1;; --no-share-printers) STATE[cups_share]=0;;
+  *) echo "_share_printers=${STATE[cups_share]}";; esac; return 0; }
+
+launchctl(){ case "$1" in
+  list) local k; for k in "${!STATE[@]}"; do [[ "$k" == launchd_* && "${STATE[$k]}" == loaded ]] && echo "${k#launchd_}"; done;;
+  load) local l; l="$(basename "$3" .plist)"; STATE[launchd_$l]=loaded;;
+  unload) local l; l="$(basename "$3" .plist)"; STATE[launchd_$l]=unloaded;;
+  print) return 1;;          # no AEServer/sshd job known -> RAE not journaled
+  enable|disable) return 0;; # FDA-independent RAE revert is a no-op in the stub
+  esac; return 0; }
+
+pgrep(){ return 1; }   # ARDAgent not running -> ARD revert not recorded (best-effort, excluded)
+
+# Neutralise the destructive / file-restore parts of the rollback (not under test here)
+find(){ return 0; }            # restore loop iterates over nothing
+killall(){ :; }                # MUST NOT kill the real Finder/cfprefsd
+pwpolicy(){ :; }
+visudo(){ return 0; }
+
+# Logging stubs used by the sourced backup.sh helpers
+debug(){ :; }; info(){ :; }; warn(){ :; }; success(){ :; }; error(){ :; }
+
+DRY_RUN=false
+# Point the firewall seam at the function stub so capture + replay stay in-process
+# and never touch the real firewall.
+export OPSEK_SOCKETFILTERFW=socketfilterfw
+IFS=$'\n\t'
+source "$REPO/utils/backup.sh"
+
+# =============================================================================
+echo "=== TEST A: full capture -> harden -> rollback round-trip (REAL code) ==="
+SNAP="$(mktemp -d)/backup_20260101_010101"; mkdir -p "$SNAP"
+REVERT_JOURNAL="$SNAP/revert_state.sh"
+TIMESTAMP=20260101_010101
+
+# 1) Initial (unhardened) machine
+STATE=();
+STATE[gatekeeper]=disabled
+STATE[fw_global]=0; STATE[fw_stealth]=disabled; STATE[fw_block]=disabled
+STATE[smb_guest]=1; STATE[nat]=1   # afp_guest is file-restored, not journaled
+STATE[womp]=1; STATE[hibernatemode]=3; STATE[standby]=1
+STATE[wifi_en0]=On
+STATE[ipv6_Wi-Fi]=Automatic
+STATE[cups_share]=1
+STATE[launchd_com.apple.screensharing]=loaded
+STATE[launchd_com.apple.smbd]=loaded
+STATE[launchd_org.cups.cupsd]=loaded
+STATE[launchd_com.apple.blued]=loaded
+STATE[launchd_com.apple.dhcp6d]=loaded
+STATE[launchd_com.apple.bluetoothaudiod]=loaded
+STATE[nvram_boot-args]="oldargs"
+# airport association flags + system MultipleSessionEnabled are absent before
+# Apply (the common real case): capture must journal a DELETE, and Restore must
+# remove them again. They are deliberately NOT seeded into STATE here.
+# (nvram bluetoothHostControllerSwitchBehavior intentionally unset)
+
+INIT=(); for k in "${!STATE[@]}"; do INIT[$k]="${STATE[$k]}"; done
+
+# 2) REAL capture
+init_revert_journal
+snapshot_system_state paranoid
+echo "  journal entries captured: $(grep -cvE '^[[:space:]]*(#|$)' "$REVERT_JOURNAL")"
+
+# 3) Simulate what the hardening functions do to the system
+STATE[gatekeeper]=enabled
+STATE[fw_global]=1; STATE[fw_stealth]=enabled; STATE[fw_block]=enabled
+STATE[smb_guest]=0; STATE[nat]=0
+STATE[womp]=0; STATE[hibernatemode]=25
+STATE[wifi_en0]=Off
+STATE[ipv6_Wi-Fi]=Off
+STATE[cups_share]=0
+STATE[launchd_com.apple.screensharing]=unloaded
+STATE[launchd_com.apple.smbd]=unloaded
+STATE[launchd_org.cups.cupsd]=unloaded
+STATE[launchd_com.apple.blued]=unloaded
+STATE[launchd_com.apple.dhcp6d]=unloaded
+STATE[launchd_com.apple.bluetoothaudiod]=unloaded
+STATE[nvram_boot-args]="slide=0 -v"
+STATE[nvram_bluetoothHostControllerSwitchBehavior]="never"
+# hardening sets the association flags + MultipleSessionEnabled
+STATE[airport_DisableAssociation]=1
+STATE[airport_AllowEnable]=0
+STATE[gp_MultipleSessionEnabled]=0
+
+# 4) REAL rollback generation + execution (file/destructive parts stubbed out).
+# Source in the CURRENT shell (not $(...) which is a subshell) so the stubs'
+# STATE mutations are observable. Reset set-flags afterward (the rollback runs
+# `set -euo pipefail` which would otherwise leak into the assertions).
+generate_rollback_script "$SNAP" "$TIMESTAMP"
+source "$SNAP/rollback_hardening_$TIMESTAMP.sh" > /tmp/opsek_rb_out.txt 2>&1 || true
+set +euo pipefail 2>/dev/null || true
+OUT="$(cat /tmp/opsek_rb_out.txt)"
+
+# 5) Assert the system returned to its exact pre-Apply state
+for k in "${!INIT[@]}"; do
+  if [[ "${STATE[$k]:-__MISSING__}" == "${INIT[$k]}" ]]; then ok "$k restored to '${INIT[$k]}'"; else no "$k = '${STATE[$k]:-__MISSING__}', expected '${INIT[$k]}'"; fi
+done
+# the nvram bluetooth var must be gone again (was unset initially)
+[[ -z "${STATE[nvram_bluetoothHostControllerSwitchBehavior]+x}" ]] && ok "nvram bluetooth override removed (back to unset)" || no "nvram bluetooth override still set: ${STATE[nvram_bluetoothHostControllerSwitchBehavior]}"
+# keys absent before Apply must be DELETED again by the revert (not left set)
+for absent_key in airport_DisableAssociation airport_AllowEnable gp_MultipleSessionEnabled; do
+  [[ -z "${STATE[$absent_key]+x}" ]] && ok "$absent_key removed (back to absent)" || no "$absent_key still set: ${STATE[$absent_key]}"
+done
+# the rollback must declare clean success (no file restore failures here)
+echo "$OUT" | grep -q "OPSEK_ROLLBACK_OK" && ok "rollback printed OPSEK_ROLLBACK_OK" || no "missing OPSEK_ROLLBACK_OK sentinel"
+
+# =============================================================================
+echo
+echo "=== TEST B: systemsetup without Full Disk Access records no failing revert ==="
+# When systemsetup cannot read state (FDA denied), capture must skip RAE/NTP so
+# the journal never carries a line guaranteed to warn at replay.
+SNAP2="$(mktemp -d)/backup_b"; mkdir -p "$SNAP2"; REVERT_JOURNAL="$SNAP2/revert_state.sh"
+STATE=(); STATE[gatekeeper]=enabled; STATE[fw_global]=1; STATE[fw_stealth]=enabled; STATE[fw_block]=disabled
+systemsetup(){ echo "setremoteappleevents: requires Full Disk Access" >&2; return 1; }
+init_revert_journal
+snapshot_system_state recommended
+if grep -q "systemsetup" "$REVERT_JOURNAL"; then no "FDA-blocked systemsetup still journaled a revert"; else ok "no systemsetup revert journaled when FDA is denied"; fi
+# Firewall must still be captured (to its dedicated file) even when systemsetup is blind.
+grep -q -- "--setglobalstate" "$SNAP2/firewall_restore.sh" 2>/dev/null && ok "firewall captured to firewall_restore.sh under no-FDA" || no "firewall capture lost under no-FDA"
+# restore the working systemsetup stub for any later use
+systemsetup(){ case "$1" in -getremoteappleevents) echo "Remote Apple Events: ${STATE[rae]}";; esac; return 0; }
+
+# =============================================================================
+echo
+echo "=== TEST C: static lint of the rollback contract ==="
+BK="$REPO/utils/backup.sh"
+grep -q "! -name 'revert_state.sh'" "$BK" && ok "restore loop excludes revert_state.sh" || no "restore loop does NOT exclude revert_state.sh (would copy journal to /)"
+grep -q "! -name '\*.meta'" "$BK" && ok "restore loop excludes *.meta" || no "restore loop does NOT exclude *.meta"
+grep -q "OPSEK_ROLLBACK_PARTIAL" "$BK" && ok "rollback can report PARTIAL on file failures" || no "rollback has no PARTIAL sentinel"
+grep -q "SystemConfiguration/\*) continue" "$BK" && ok "restore loop skips configd-owned SystemConfiguration plists" || no "restore loop still cp's SystemConfiguration plists"
+grep -q "com.apple.alf.plist) continue" "$BK" && ok "restore loop skips daemon-owned com.apple.alf.plist" || no "restore loop still cp's alf.plist (would clobber firewall)"
+grep -q "firewall_restore.sh" "$BK" && ok "firewall applied via dedicated last-pass file" || no "no dedicated firewall restore pass"
+grep -q "OPSEK_APPLY_OK" "$REPO/utils/common.sh" && ok "apply emits OPSEK_APPLY_OK sentinel" || no "apply has no success sentinel"
+
+# =============================================================================
+echo
+echo "Result: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]] && { echo "ALL GREEN"; exit 0; } || { echo "SOME FAILED"; exit 1; }

--- a/macos/tests/run.sh
+++ b/macos/tests/run.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# OPSEK macOS test runner
+#
+# Runs the shell-level verification suite. There is no CI in this repo, so this
+# is the gate: run it before shipping any change to the backup / restore path.
+#
+#   bash macos/tests/run.sh
+#
+# Exit status is non-zero if any test fails, so it can be wired into a hook or a
+# documented `make verify`.
+# ==============================================================================
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+rc=0
+
+echo "### OPSEK shell test suite"
+echo
+
+echo ">>> roundtrip_test.sh"
+bash "$DIR/roundtrip_test.sh" || rc=1
+echo
+
+if [[ "$rc" -eq 0 ]]; then
+    echo "### ALL SUITES GREEN"
+else
+    echo "### SUITE FAILURES (see above)"
+fi
+exit "$rc"

--- a/macos/utils/backup.sh
+++ b/macos/utils/backup.sh
@@ -4,6 +4,290 @@
 # Backup system for macOS hardening script
 # ==============================================================================
 
+# ------------------------------------------------------------------------------
+# Revert journal
+#
+# Hardening applies two kinds of change: file edits (handled by backup_file and
+# restored by the rollback script) and live system toggles (socketfilterfw,
+# spctl, systemsetup, launchctl, pmset, nvram, networksetup) that no file
+# captures. The revert journal records, before any toggle is changed, the
+# command that puts each toggle back to its pre-Apply value. The rollback runs
+# the journal so Restore actually undoes the hardening, not just the files.
+#
+# DISCIPLINE: when you add a toggle-based hardening function, add its capture to
+# snapshot_system_state below (mirrors the "define function AND add to profile"
+# rule). Settings backed by a plist do not belong here; give them a backup_file
+# call in their function instead.
+# ------------------------------------------------------------------------------
+
+# Create the journal file inside the snapshot dir. No-op under dry-run.
+init_revert_journal() {
+    [[ "$DRY_RUN" == true ]] && return 0
+    [[ -z "${REVERT_JOURNAL:-}" ]] && return 0
+    {
+        printf '# OPSEK revert journal generated %s\n' "${TIMESTAMP:-unknown}"
+        printf '# One restore command per line; executed by the rollback script.\n'
+    } > "$REVERT_JOURNAL" 2>/dev/null || true
+    chmod 600 "$REVERT_JOURNAL" 2>/dev/null || true
+}
+
+# Append one restore command to the journal. The command is eval'd verbatim by
+# the rollback (as root), so it must already be fully expanded. No-op under
+# dry-run or before the journal exists.
+record_revert() {
+    local cmd="$1"
+    [[ "$DRY_RUN" == true ]] && return 0
+    [[ -z "${REVERT_JOURNAL:-}" ]] && return 0
+    printf '%s\n' "$cmd" >> "$REVERT_JOURNAL" 2>/dev/null || true
+}
+
+# If a launchd job is currently loaded, record the command that loads it again,
+# so a later `launchctl unload -w` during hardening can be reversed.
+_record_launchd_revert() {
+    local label="$1" plist="$2"
+    if launchctl list 2>/dev/null | grep -q "$label"; then
+        record_revert "launchctl load -w '$plist'"
+    fi
+}
+
+# Journal the inverse of a `defaults write <domain> <key>`: restore the prior
+# value, or delete the key if it was absent before Apply. FDA-independent and
+# configd-safe (it replays through defaults, not a raw cp), so it is the right
+# tool for configd-owned SystemConfiguration plists and for keys that did not
+# exist before hardening. <domain> may be a bare domain or a full plist path.
+_record_defaults_revert() {
+    local domain="$1" key="$2" type="${3:-}"
+    local cur
+    cur="$(defaults read "$domain" "$key" 2>/dev/null || true)"
+    if [[ -n "$cur" ]]; then
+        # `defaults read` returns 0/1 for booleans, but `defaults write -bool`
+        # only accepts true|false|yes|no (a bare 0/1 errors out). Translate.
+        if [[ "$type" == "bool" ]]; then
+            case "$cur" in
+                1|true|TRUE|yes|YES) cur=true ;;
+                0|false|FALSE|no|NO) cur=false ;;
+            esac
+        fi
+        if [[ -n "$type" ]]; then
+            record_revert "defaults write $domain '$key' -$type '$cur'"
+        else
+            record_revert "defaults write $domain '$key' '$cur'"
+        fi
+    else
+        record_revert "defaults delete $domain '$key' 2>/dev/null || true"
+    fi
+}
+
+# Capture the pre-Apply state of every live toggle the profiles change, recording
+# the inverse into the journal. Reads run as root (Apply context); each read is
+# guarded so a missing tool or `set -e` never aborts the run. Captures common to
+# both profiles always run; paranoid-only toggles are gated on the profile so the
+# recommended snapshot does not list reverts for things it never touched.
+snapshot_system_state() {
+    local profile="${1:-recommended}"
+
+    [[ "$DRY_RUN" == true ]] && return 0
+    [[ -z "${REVERT_JOURNAL:-}" ]] && return 0
+
+    debug "Capturing system state for revert journal (profile: $profile)"
+
+    # --- Common to recommended and paranoid -----------------------------------
+
+    # Gatekeeper (enable_gatekeeper). Faithful: re-disable if it was off.
+    if spctl --status 2>/dev/null | grep -q "assessments enabled"; then
+        record_revert "spctl --master-enable"
+    else
+        record_revert "spctl --master-disable"
+    fi
+
+    # Application firewall (enable_firewall, enable_firewall_block_all). Captured
+    # to a DEDICATED file, NOT the journal, because the rollback must apply the
+    # firewall LAST, after cfprefsd and the firewall daemon have restarted.
+    # com.apple.alf.plist is owned by com.apple.alf.agent; restoring it by cp and
+    # then killing cfprefsd makes the daemon re-sync and overwrite an earlier
+    # toggle, which is why a journal-time `setglobalstate off` ran yet did not
+    # stick. Applying the firewall once at the very end avoids that race.
+    # OPSEK_SOCKETFILTERFW lets the round-trip harness point this at a function
+    # stub; command -v matches both an absolute path and a function name.
+    local fw="${OPSEK_SOCKETFILTERFW:-/usr/libexec/ApplicationFirewall/socketfilterfw}"
+    local fw_target="$(dirname "$REVERT_JOURNAL")/firewall_restore.sh"
+    if command -v "$fw" >/dev/null 2>&1; then
+        local fw_global fw_stealth fw_block g s b
+        fw_global="$("$fw" --getglobalstate 2>/dev/null || true)"
+        fw_stealth="$("$fw" --getstealthmode 2>/dev/null || true)"
+        fw_block="$("$fw" --getblockall 2>/dev/null || true)"
+        # "(State = 0)" is the only off state; 1 and 2 are both on. "disabled"
+        # never contains the substring "enabled", so -i is safe for the others.
+        echo "$fw_global"  | grep -q  "State = 0" && g=off || g=on
+        echo "$fw_stealth" | grep -qi "enabled"   && s=on  || s=off
+        echo "$fw_block"   | grep -qi "enabled"   && b=on  || b=off
+        # Global state last: if it ends up off, stealth/blockall are moot anyway.
+        {
+            printf "'%s' --setstealthmode %s\n" "$fw" "$s"
+            printf "'%s' --setblockall %s\n"    "$fw" "$b"
+            printf "'%s' --setglobalstate %s\n" "$fw" "$g"
+        } > "$fw_target" 2>/dev/null || true
+        chmod 600 "$fw_target" 2>/dev/null || true
+    fi
+
+    # Remote Apple Events (disable_remote_apple_events). systemsetup
+    # -setremoteappleevents needs Full Disk Access (it warns under the GUI's
+    # root-without-FDA context) and the feature is absent on most modern Macs.
+    # Revert through the launchd job instead, which is FDA-independent: only
+    # record a revert when the AEServer job actually exists and is currently
+    # loaded (RAE on), so a Mac without RAE journals nothing to fail.
+    if launchctl print system/com.apple.AEServer >/dev/null 2>&1; then
+        record_revert "launchctl enable system/com.apple.AEServer"
+    fi
+
+    # Network time (configure_time_sync) is intentionally NOT journaled: no audit
+    # check reads it, and systemsetup -setusingnetworktime needs Full Disk Access
+    # so it only ever produced a guaranteed-to-fail revert line.
+
+    # Internet Sharing NAT (disable_internet_sharing). A SystemConfiguration
+    # plist owned by configd, so it is reverted via defaults (the restore loop
+    # skips that directory). Read the nested NAT dict and journal the inverse.
+    local nat_enabled
+    nat_enabled="$(defaults read /Library/Preferences/SystemConfiguration/com.apple.nat NAT 2>/dev/null | grep -oE 'Enabled = [0-9]' | grep -oE '[0-9]' || true)"
+    if [[ "$nat_enabled" == "1" ]]; then
+        record_revert "defaults write /Library/Preferences/SystemConfiguration/com.apple.nat NAT -dict Enabled -int 1"
+    elif [[ "$nat_enabled" == "0" ]]; then
+        record_revert "defaults write /Library/Preferences/SystemConfiguration/com.apple.nat NAT -dict Enabled -int 0"
+    fi
+
+    # Guest access to shared folders (disable_guest_shared_folders). Only the SMB
+    # plist lives under SystemConfiguration (configd-owned, skipped by the cp
+    # loop) so it needs the journal. AppleFileServer.plist is a normal
+    # /Library/Preferences file and is restored by the cp loop, so journaling it
+    # too would be redundant (and was the source of a spurious revert warning).
+    _record_defaults_revert "/Library/Preferences/SystemConfiguration/com.apple.smb.server" "AllowGuestAccess" "bool"
+
+    # Printer sharing (disable_printer_sharing).
+    if cupsctl 2>/dev/null | grep -q "_share_printers=1"; then
+        record_revert "cupsctl --share-printers"
+        record_revert "launchctl load -w '/System/Library/LaunchDaemons/org.cups.cupsd.plist'"
+    fi
+
+    # Wake-on-LAN + hibernate (disable_wake_on_lan, configure_hibernate_mode,
+    # harden_kernel). Capture the currently active pmset values.
+    local pm key
+    for key in womp hibernatemode standby standbydelay DestroyFVKeyOnStandby; do
+        pm="$(pmset -g 2>/dev/null | awk -v k="$key" '$1==k{print $2; exit}' || true)"
+        if [[ -n "$pm" ]]; then
+            case "$key" in
+                DestroyFVKeyOnStandby) record_revert "pmset -a destroyfvkeyonstandby $pm" ;;
+                *) record_revert "pmset -a $key $pm" ;;
+            esac
+        fi
+    done
+
+    # --- Aggressive toggles (paranoid, and custom per-module runs) ------------
+    # Anything that is not the recommended profile may touch these, so capture
+    # the full set. Recording a revert for a toggle that was not actually changed
+    # is safe: on Restore it is set back to the value it already has (a no-op).
+    if [[ "$profile" != "recommended" ]]; then
+        # Sharing / remote-access daemons (disable_screen_sharing,
+        # disable_file_sharing, disable_http_server, disable_nfs_server,
+        # disable_unnecessary_daemons).
+        _record_launchd_revert "com.apple.screensharing" "/System/Library/LaunchDaemons/com.apple.screensharing.plist"
+        _record_launchd_revert "com.apple.AppleFileServer" "/System/Library/LaunchDaemons/com.apple.AppleFileServer.plist"
+        _record_launchd_revert "com.apple.smbd" "/System/Library/LaunchDaemons/com.apple.smbd.plist"
+        _record_launchd_revert "org.apache.httpd" "/System/Library/LaunchDaemons/org.apache.httpd.plist"
+        _record_launchd_revert "com.apple.nfsd" "/System/Library/LaunchDaemons/com.apple.nfsd.plist"
+        _record_launchd_revert "com.apple.netbiosd" "/System/Library/LaunchDaemons/com.apple.netbiosd.plist"
+        _record_launchd_revert "com.apple.AppleShareClientCore" "/System/Library/LaunchDaemons/com.apple.AppleShareClientCore.plist"
+        # Remaining daemons from disable_unnecessary_daemons not covered above.
+        _record_launchd_revert "com.apple.dhcp6d" "/System/Library/LaunchDaemons/com.apple.dhcp6d.plist"
+        _record_launchd_revert "com.apple.alf.useragent" "/System/Library/LaunchDaemons/com.apple.alf.useragent.plist"
+
+        # Bluetooth service daemons/agents (disable_all_bluetooth_services). Power
+        # state itself reverts via the Bluetooth plists; these reload the helper
+        # services that were unloaded. Best effort: only if currently loaded.
+        local bt_svc
+        for bt_svc in com.apple.bluetoothReporter com.apple.bluetoothaudiod com.apple.BluetoothReporter com.apple.bluetooth.cupsd; do
+            _record_launchd_revert "$bt_svc" "/System/Library/LaunchDaemons/$bt_svc.plist"
+            _record_launchd_revert "$bt_svc" "/System/Library/LaunchAgents/$bt_svc.plist"
+        done
+
+        # Wi-Fi association flags (disable_wifi). SystemConfiguration plist owned
+        # by configd: revert via defaults, restored as the live Wi-Fi power is.
+        _record_defaults_revert "/Library/Preferences/SystemConfiguration/com.apple.airport.preferences" "DisableAssociation" "bool"
+        _record_defaults_revert "/Library/Preferences/SystemConfiguration/com.apple.airport.preferences" "AllowEnable" "bool"
+
+        # Location services (disable_location_services). Owned by the locationd
+        # daemon; journal the inverse so the revert does not depend on a raw cp.
+        _record_defaults_revert "/var/db/locationd/Library/Preferences/ByHost/com.apple.locationd" "LocationServicesEnabled" "bool"
+
+        # Fast user switching (disable_fast_user_switching) writes the SYSTEM
+        # .GlobalPreferences, which no backup_file captures (the function backs up
+        # loginwindow.plist by mistake). Journal the inverse here.
+        _record_defaults_revert "/Library/Preferences/.GlobalPreferences" "MultipleSessionEnabled" "bool"
+
+        # Admin password for system-wide preferences (require_admin_system_prefs)
+        # flips the system.preferences authorization right's "shared" flag. It is
+        # not file-backed; capture the current value and journal a best-effort
+        # restore through authorizationdb.
+        local sp_shared
+        sp_shared="$(security authorizationdb read system.preferences 2>/dev/null | plutil -extract shared raw - 2>/dev/null || true)"
+        if [[ "$sp_shared" == "true" || "$sp_shared" == "false" ]]; then
+            record_revert "__opsek_tmp=\$(mktemp) && security authorizationdb read system.preferences > \"\$__opsek_tmp\" 2>/dev/null && defaults write \"\$__opsek_tmp\" shared -bool $sp_shared && security authorizationdb write system.preferences < \"\$__opsek_tmp\"; rm -f \"\$__opsek_tmp\""
+        fi
+
+        # Remote Management / ARD (disable_remote_management). Best effort: only
+        # if the agent is currently running.
+        if pgrep -x ARDAgent >/dev/null 2>&1; then
+            record_revert "/System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart -activate -configure -access -on -restart -agent"
+        fi
+
+        # Wi-Fi power per interface (disable_wifi). Only if currently on.
+        local wifi_ifaces iface pw
+        wifi_ifaces="$(networksetup -listallhardwareports 2>/dev/null | awk '/Wi-Fi|AirPort/{getline; print $2}' || true)"
+        for iface in $wifi_ifaces; do
+            [[ -z "$iface" ]] && continue
+            pw="$(networksetup -getairportpower "$iface" 2>/dev/null || true)"
+            echo "$pw" | grep -qi "): On" && record_revert "networksetup -setairportpower '$iface' on"
+        done
+
+        # IPv6 per network service (disable_ipv6_on_interfaces). Record a revert
+        # only where IPv6 is currently automatic (the common case we change).
+        local services svc
+        services="$(networksetup -listallnetworkservices 2>/dev/null | tail -n +2 || true)"
+        while IFS= read -r svc; do
+            [[ -z "$svc" || "$svc" == *"*"* ]] && continue
+            if networksetup -getinfo "$svc" 2>/dev/null | grep -qi "IPv6: Automatic"; then
+                record_revert "networksetup -setv6automatic '$svc'"
+            fi
+        done <<< "$services"
+
+        # Bluetooth runtime (disable_bluetooth_completely,
+        # disable_all_bluetooth_services). The plist (ControllerPowerState) is
+        # file-backed; here we revert the nvram override and reload blued.
+        local bt_nvram
+        bt_nvram="$(nvram bluetoothHostControllerSwitchBehavior 2>/dev/null | awk '{print $2}' || true)"
+        if [[ -n "$bt_nvram" ]]; then
+            record_revert "nvram bluetoothHostControllerSwitchBehavior='$bt_nvram'"
+        else
+            record_revert "nvram -d bluetoothHostControllerSwitchBehavior"
+        fi
+        record_revert "launchctl load -w '/System/Library/LaunchDaemons/com.apple.blued.plist'"
+
+        # Kernel boot-args (harden_kernel). Restore the prior value, or remove
+        # the variable if none was set.
+        local bootargs
+        bootargs="$(nvram boot-args 2>/dev/null | sed -e 's/^boot-args[[:space:]]*//' || true)"
+        if [[ -n "$bootargs" ]]; then
+            record_revert "nvram boot-args='$bootargs'"
+        else
+            record_revert "nvram -d boot-args"
+        fi
+    fi
+
+    debug "Revert journal capture complete"
+    # Always succeed: this runs as a standalone statement inside apply_profile
+    # under `set -e`, and the captures above are all best-effort.
+    return 0
+}
+
 # Generate rollback script
 generate_rollback_script() {
     local backup_dir="$1"
@@ -25,56 +309,173 @@ BACKUP_DIR="$(dirname "${BASH_SOURCE[0]}")"
 
 echo "Starting rollback from $BACKUP_DIR"
 
-# Restore plist files
-find "$BACKUP_DIR" -name "*.plist" | while read -r plist; do
-    filename=$(basename "$plist")
-
-    if [[ "$filename" == "com.apple."* ]]; then
-        target_dir="/Library/Preferences"
-    else
-        target_dir="$HOME/Library/Preferences"
+# Restore every backed-up file to its original absolute path. backup_file stored
+# each file mirroring its full path under the snapshot dir, so stripping that
+# prefix recovers the destination. This handles per-user files (under
+# /Users/<name>/...) and system files alike. /etc/sudoers is left to the
+# validated block below; the rollback script, the revert journal and the .meta
+# sidecar are bookkeeping, not system files, so they are skipped.
+restore_failures=0
+# Read from a process substitution, not a pipe, so the loop runs in this shell
+# and restore_failures survives (a `find | while` body runs in a subshell).
+while IFS= read -r -d '' src; do
+    dest="${src#"$BACKUP_DIR"}"
+    if [[ "$dest" == "$src" || "$dest" != /* || "$dest" == "/etc/sudoers" ]]; then
+        continue
     fi
-
-    mkdir -p "$target_dir"
-
-    echo "Restoring $filename to $target_dir"
-    cp "$plist" "$target_dir/" 2>/dev/null || echo "Failed to restore $filename"
-done
-
-# Restore other configuration files
-if [[ -f "$BACKUP_DIR/etc/security/audit_control" ]]; then
-    echo "Restoring audit_control"
-    cp "$BACKUP_DIR/etc/security/audit_control" "/etc/security/audit_control" 2>/dev/null || true
-fi
+    # Daemon-owned plists must not be cp'd back: configd (SystemConfiguration)
+    # rejects the write, and com.apple.alf.plist (the firewall) gets re-synced
+    # and overwritten by its daemon, clobbering the firewall toggle. These are
+    # reverted through the journal / dedicated firewall pass instead.
+    case "$dest" in
+        /Library/Preferences/SystemConfiguration/*) continue ;;
+        /Library/Preferences/com.apple.alf.plist) continue ;;
+    esac
+    mkdir -p "$(dirname "$dest")" 2>/dev/null || true
+    if cp -p "$src" "$dest" 2>/dev/null; then
+        # Give per-user files back to their owner: cp as root would otherwise
+        # leave the account unable to manage its own preferences.
+        case "$dest" in
+            /Users/*/*)
+                owner="$(echo "$dest" | cut -d/ -f3)"
+                if [[ -n "$owner" && "$owner" != "Shared" ]]; then
+                    chown "$owner" "$dest" 2>/dev/null || true
+                fi
+                ;;
+        esac
+        echo "Restored $dest"
+    else
+        echo "Failed to restore $dest"
+        restore_failures=$((restore_failures + 1))
+    fi
+done < <(find "$BACKUP_DIR" -type f \
+    ! -name 'rollback_hardening_*.sh' \
+    ! -name 'revert_state.sh' \
+    ! -name 'firewall_restore.sh' \
+    ! -name '*.meta' \
+    -print0)
 
 if [[ -f "$BACKUP_DIR/etc/sudoers" ]]; then
     echo "Validating sudoers file before restore"
 
     if visudo -c -f "$BACKUP_DIR/etc/sudoers"; then
-        echo "Sudoers file valid — restoring"
+        echo "Sudoers file valid, restoring"
         cp "$BACKUP_DIR/etc/sudoers" "/etc/sudoers"
         chmod 0440 /etc/sudoers
     else
-        echo "ERROR: Backup sudoers file is invalid — restore aborted"
+        echo "ERROR: Backup sudoers file is invalid, restore aborted"
     fi
 fi
 
 # Remove timeout sudoers file if it exists
 rm -f /etc/sudoers.d/timeout 2>/dev/null || true
 
+# Clear any password policy applied by the hardening (configure_password_policy).
+# Safe no-op when none was set. Prevents a restored system from keeping content
+# rules the user no longer wants.
+pwpolicy -clearaccountpolicies 2>/dev/null || true
+pwpolicy -n /Local/Default -setglobalpolicy "" 2>/dev/null || true
+
+# Replay the revert journal: re-apply each captured toggle to its pre-Apply
+# value. Best effort; some reverts (a service that was not present, an nvram
+# variable that was already unset) can warn without being a real failure.
+reverted=0
+revert_warnings=0
+if [[ -f "$BACKUP_DIR/revert_state.sh" ]]; then
+    echo "Reverting system toggles from the revert journal"
+    while IFS= read -r line; do
+        case "$line" in
+            ''|\#*) continue ;;
+        esac
+        if eval "$line" >/dev/null 2>&1; then
+            reverted=$((reverted + 1))
+        else
+            revert_warnings=$((revert_warnings + 1))
+            echo "  warning: could not apply revert: $line"
+        fi
+    done < "$BACKUP_DIR/revert_state.sh"
+fi
+
 # Restart affected services
 launchctl unload /System/Library/LaunchDaemons/com.apple.auditd.plist 2>/dev/null || true
 launchctl load /System/Library/LaunchDaemons/com.apple.auditd.plist 2>/dev/null || true
 
+# Reload the preferences daemon so restored per-user plists take effect without
+# a logout (cfprefsd caches preferences in memory).
+killall cfprefsd 2>/dev/null || true
 killall SystemUIServer 2>/dev/null || true
 killall Finder 2>/dev/null || true
 
-echo "Rollback completed. Some changes may require a reboot to take full effect."
-echo "Please review system settings manually to ensure proper restoration."
+# Re-apply the firewall LAST, once the daemons above have settled. Done earlier,
+# restoring com.apple.alf.plist and killing cfprefsd makes the firewall daemon
+# re-sync and overwrite the toggle, so the firewall is applied here at the very
+# end (and the alf.plist file is deliberately not restored, see the cp loop).
+if [[ -f "$BACKUP_DIR/firewall_restore.sh" ]]; then
+    echo "Re-applying firewall state (final pass)"
+    while IFS= read -r fwline; do
+        case "$fwline" in ''|\#*) continue ;; esac
+        eval "$fwline" >/dev/null 2>&1 || true
+    done < "$BACKUP_DIR/firewall_restore.sh"
+fi
+
+echo ""
+echo "Rollback summary:"
+echo "  Files restored from snapshot (failures: $restore_failures)."
+echo "  System toggles reverted: $reverted (warnings: $revert_warnings)."
+echo "Some settings take full effect only after a restart."
+echo "Note: a few steps are intentionally not reverted because undoing them would"
+echo "weaken the Mac or cannot be undone safely. The root account stays disabled,"
+echo "tightened file permissions are left in place, and a removed Guest home is not"
+echo "recreated."
+# File restores are the hard guarantee, so they decide OK vs PARTIAL. Toggle
+# revert warnings are best-effort (a service that was not loaded, an nvram
+# variable already unset) and are reported above without failing the restore.
+if [[ "$restore_failures" -eq 0 ]]; then
+    echo "OPSEK_ROLLBACK_OK"
+else
+    echo "OPSEK_ROLLBACK_PARTIAL restore_failures=$restore_failures"
+fi
 ROLL
     
     chmod +x "$rollback_script"
     info "Rollback helper saved: $rollback_script"
+}
+
+# Write a world-readable <backup_dir>.meta sidecar so the non-root GUI can show
+# the file count, size and rollback name without descending into the 700
+# snapshot dir. Format: fileCount|sizeBytes|rollbackScriptName
+write_snapshot_metadata() {
+    local backup_dir="$1"
+    local timestamp="$2"
+
+    if [[ -z "$backup_dir" || -z "$timestamp" ]]; then
+        return 0
+    fi
+    if [[ "$DRY_RUN" == true ]]; then
+        return 0
+    fi
+    [[ -d "$backup_dir" ]] || return 0
+
+    # `|| true` so a non-zero find/du under pipefail does not trip set -e.
+    # The displayed count is "restorable changes": backed-up config files (not the
+    # rollback helper or the journal itself) plus the number of toggle reverts
+    # captured in the journal. This keeps the count meaningful and never shows 0
+    # for a real Apply that only changed system toggles.
+    local file_count revert_count change_count size_kb size_bytes meta_file
+    file_count="$(find "$backup_dir" -type f ! -name 'rollback_hardening_*.sh' ! -name 'revert_state.sh' 2>/dev/null | wc -l | tr -d ' ' || true)"
+    revert_count=0
+    if [[ -f "$backup_dir/revert_state.sh" ]]; then
+        revert_count="$(grep -cvE '^[[:space:]]*(#|$)' "$backup_dir/revert_state.sh" 2>/dev/null | tr -d ' ' || true)"
+    fi
+    change_count=$(( ${file_count:-0} + ${revert_count:-0} ))
+    size_kb="$(du -sk "$backup_dir" 2>/dev/null | awk '{print $1}' || true)"
+    size_bytes=$(( ${size_kb:-0} * 1024 ))
+    meta_file="${backup_dir}.meta"
+
+    printf '%s|%s|%s\n' "${change_count:-0}" "${size_bytes:-0}" "rollback_hardening_${timestamp}.sh" \
+        > "$meta_file" 2>/dev/null || true
+    chmod 644 "$meta_file" 2>/dev/null || true
+    debug "Snapshot metadata written: $meta_file"
 }
 
 # Create backup of a file
@@ -105,6 +506,8 @@ cleanup_old_backups_in_dir() {
     
     if [[ -d "$backup_root" ]]; then
         find "$backup_root" -type d -name "backup_*" -mtime +$retention_days -exec rm -rf {} \; 2>/dev/null || true
+        # Remove the matching .meta sidecars too.
+        find "$backup_root" -type f -name "backup_*.meta" -mtime +$retention_days -exec rm -f {} \; 2>/dev/null || true
         info "Old backups cleaned up in $backup_root (older than $retention_days days)"
     fi
 }

--- a/macos/utils/common.sh
+++ b/macos/utils/common.sh
@@ -67,6 +67,106 @@ execute() {
     fi
 }
 
+# --------------------------------------------------------------------------
+# Per-user context
+#
+# The script runs as root (sudo). Under sudo, $HOME, `~`, and a bare
+# `defaults`/`security` call resolve to root, so any per-user setting would be
+# written to /var/root instead of the person actually logged in. That is why
+# screen lock, Finder, Safari, AirDrop and similar settings appeared to "not
+# change". Resolve the real console user once and route per-user changes
+# through user_execute / user_defaults so they land in the right account.
+# --------------------------------------------------------------------------
+
+# Populated by detect_target_user. Declared here so `set -u` never trips on
+# them before detection runs.
+TARGET_USER="${TARGET_USER:-}"
+TARGET_UID="${TARGET_UID:-}"
+TARGET_HOME="${TARGET_HOME:-}"
+
+detect_target_user() {
+    if [[ -n "${SUDO_USER:-}" && "$SUDO_USER" != "root" ]]; then
+        TARGET_USER="$SUDO_USER"
+    else
+        TARGET_USER="$(/usr/bin/stat -f%Su /dev/console 2>/dev/null || true)"
+    fi
+
+    if [[ -z "$TARGET_USER" || "$TARGET_USER" == "root" || "$TARGET_USER" == "loginwindow" ]]; then
+        TARGET_USER=""
+        TARGET_UID=""
+        TARGET_HOME=""
+        warn "Could not determine a non-root login user. Per-user settings (screen lock, Finder, Safari, AirDrop) will be skipped."
+        return 0
+    fi
+
+    TARGET_UID="$(id -u "$TARGET_USER" 2>/dev/null || true)"
+    TARGET_HOME="$(/usr/bin/dscl . -read "/Users/$TARGET_USER" NFSHomeDirectory 2>/dev/null | awk '{print $2}')"
+    [[ -z "$TARGET_HOME" ]] && TARGET_HOME="/Users/$TARGET_USER"
+    info "Applying per-user settings as: $TARGET_USER (uid $TARGET_UID, home $TARGET_HOME)"
+}
+
+# Run a command as the target login user, inside their per-user launchd
+# context, so `defaults`/`security` write to that account and cfprefsd picks
+# the change up. Honors DRY_RUN. Returns non-zero (but never aborts) on
+# failure so an unsupported per-user tweak does not sink the whole run.
+user_execute() {
+    local cmd="$1"
+    debug "User execute ($TARGET_USER): $cmd"
+
+    if [[ "$DRY_RUN" == true ]]; then
+        info "[DRY-RUN] Would execute as ${TARGET_USER:-<no user>}: $cmd"
+        return 0
+    fi
+
+    if [[ -z "$TARGET_USER" || -z "$TARGET_UID" ]]; then
+        warn "No login user resolved, skipping per-user command: $cmd"
+        return 1
+    fi
+
+    if launchctl asuser "$TARGET_UID" sudo -u "$TARGET_USER" /bin/bash -c "$cmd" 2>&1 | tee -a "$LOGFILE" > /dev/null; then
+        success "Command succeeded (user $TARGET_USER): $cmd"
+        return 0
+    else
+        warn "Command failed (user $TARGET_USER): $cmd"
+        return 1
+    fi
+}
+
+# Convenience wrapper for a per-user `defaults` invocation.
+user_defaults() {
+    user_execute "defaults $*"
+}
+
+# Read a value from the target user's defaults domain (for the audit/checks).
+# Prints the value on stdout and returns the underlying status. Returns 1 with
+# no output when no login user was resolved.
+user_defaults_read() {
+    [[ -z "$TARGET_USER" ]] && return 1
+    sudo -u "$TARGET_USER" defaults read "$@" 2>/dev/null
+}
+
+# Same, for a per-user ByHost (-currentHost) value.
+user_defaults_read_currenthost() {
+    [[ -z "$TARGET_USER" ]] && return 1
+    sudo -u "$TARGET_USER" defaults -currentHost read "$@" 2>/dev/null
+}
+
+# Read the login user's real screen-lock state via sysadminctl (the inert
+# com.apple.screensaver keys do not reflect it on macOS 13+). Runs in the
+# user's launchd context; sysadminctl prints to stderr, hence the 2>&1.
+user_screenlock_status() {
+    [[ -z "$TARGET_USER" || -z "$TARGET_UID" ]] && return 1
+    launchctl asuser "$TARGET_UID" sudo -u "$TARGET_USER" sysadminctl -screenLock status 2>&1
+}
+
+# Backup a file that lives in the target user's home, reading it from the real
+# account rather than /var/root. No-op when no login user was resolved.
+user_backup_file() {
+    local rel="$1"   # path relative to the user home, e.g. Library/Preferences/x.plist
+    [[ -z "$TARGET_HOME" ]] && return 0
+    backup_file "$TARGET_HOME/$rel"
+}
+
 # Backup file before modification
 backup_file() {
     local file="$1"
@@ -207,11 +307,16 @@ apply_profile() {
         *) error "Unknown profile: $profile"; return 1 ;;
     esac
     
+    # Capture the pre-Apply state of system toggles into the revert journal
+    # before any hardening runs, so Restore can put them back. No-op in dry-run.
+    snapshot_system_state "$profile"
+
     # Execute each function from normalized array
     while IFS= read -r line; do
         profile_array+=("$line")
     done <<< "$profile_functions"
     
+    local apply_failures=0
     for rawfunc in "${profile_array[@]}"; do
         func="$(_trim "$rawfunc")"
         [[ -z "$func" ]] && continue
@@ -222,13 +327,24 @@ apply_profile() {
                 success "✓ $func completed"
             else
                 warn "✗ $func failed"
+                apply_failures=$((apply_failures + 1))
             fi
         else
             warn "Function not found: $func - skipping"
         fi
     done
-    
+
     success "Profile applied: $profile"
+
+    # Machine-checkable outcome the GUI gates on, so a half-applied run is never
+    # reported as a clean success. Per-function failures are warnings above (a
+    # control unsupported on this macOS build is expected), but the count is
+    # surfaced here so the Swift side can tell clean from partial.
+    if [[ "$apply_failures" -eq 0 ]]; then
+        echo "OPSEK_APPLY_OK"
+    else
+        echo "OPSEK_APPLY_FAILED failures=$apply_failures"
+    fi
 }
 
 # Clean up old backups
@@ -243,19 +359,35 @@ cleanup_old_backups() {
 init_environment() {
     # Load configuration
     load_config
-    
+
+    # Resolve the real login user so per-user settings are applied to them and
+    # not to root. Safe to call before the log file exists (uses warn/info).
+    detect_target_user
+
     # Initialize global variables
     readonly TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
     readonly HOSTNAME="$(hostname -s)"
     readonly CURRENT_BACKUP="$BACKUP_ROOT/backup_$TIMESTAMP"
+    readonly REVERT_JOURNAL="$CURRENT_BACKUP/revert_state.sh"
     readonly LOGFILE="$LOG_ROOT/macos_hardening_$TIMESTAMP.log"
     
     # Create necessary directories
     if [[ "$DRY_RUN" == false ]]; then
         execute "mkdir -p '$CURRENT_BACKUP'"
         execute "mkdir -p '$(dirname "$LOGFILE")'"
+
+        # Let the non-root GUI list the snapshot tree: /var/backups ships 700
+        # root:wheel. 711 on the parent is traverse-only, 755 on our root lists
+        # the snapshot names; each backup_<ts> dir stays 700 (contents private).
+        execute "chmod 711 '$(dirname "$BACKUP_ROOT")'"
+        execute "chmod 755 '$BACKUP_ROOT'"
+
         execute "chmod 700 '$CURRENT_BACKUP'"
         execute "chmod 600 '$LOGFILE'"
+
+        # Start the revert journal inside the snapshot dir so toggle captures
+        # have somewhere to record (see snapshot_system_state in utils/backup.sh).
+        init_revert_journal
     fi
     
     # Load modules

--- a/macos/utils/logging.sh
+++ b/macos/utils/logging.sh
@@ -98,6 +98,7 @@ HARDENING OPTIONS:
     --paranoid           Enable the 'paranoid' profile (default: recommended)
     --lockdown          Enable Lockdown Mode compatible settings (macOS 13+ only)
     --checks            Run compliance checks after hardening
+    --checks-only       Run compliance checks only, applying nothing (read-only audit)
     --dry-run           Show changes that would be made without applying them
     --yes               Assume yes to all prompts (non-interactive mode)
     --verbose           Show debug output in log


### PR DESCRIPTION
This PR groups recent macOS hardening script fixes.

It fixes per-user hardening settings being applied to the root account instead of the logged-in user when the script runs under sudo. The helpers detect_target_user, user_execute, user_defaults, user_defaults_read and user_backup_file now target the right account through launchctl asuser.

It makes the compliance checks accurate on modern macOS. The firewall checks match both modern and legacy socketfilterfw output. Screen lock uses sysadminctl -screenLock status. AirDrop, Handoff and AirPlay read live OS state from sharingd, useractivityd and controlcenter. A CIS failure no longer aborts the audit before OPSEK checks run, and critical controls are reported as errors so they weigh fully in the GUI score.

It fixes snapshot rollback so it actually returns the Mac to its pre-Apply posture. A revert_state.sh journal is captured before every toggle change. Rollback restores files to their real absolute paths, returns ownership of per-user files, reloads cfprefsd and clears the aggressive password policy.

It makes firewall restore reliable by capturing the state into a dedicated firewall_restore.sh file and applying it as the last step after the firewall daemon has settled.

It adds a --checks-only flag so the GUI can run a read-only audit without first applying the recommended profile in dry-run. Aggregate section lines are emitted as info instead of warn or success so they stop being counted as extra checks.

It updates OPSEK checks and profiles.conf so the GUI can gate Apply buttons on whether any auto-fixable findings remain.

It also cleans up comments in the hardening scripts and adds roundtrip test coverage under macos/tests/.

Files changed are the macOS scripts only: main.sh, checks/, modules/, utils/, config/, install.sh and tests/. No GUI files are included.